### PR TITLE
roll back the protecting group change

### DIFF
--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -138,14 +138,17 @@ def call_LLM(molecule: str,
     else:
         add_on = ""
 
-    # Check for protecting groups and add context
-    masked_smiles = mask_protecting_groups_multisymbol(molecule)
-    if masked_smiles != molecule and masked_smiles != "INVALID_SMILES":
-        log_message(
-            f"Detected protecting groups in molecule: {molecule} -> {masked_smiles}",
-            logger)
-        protecting_group_context = f"\n\nPROTECTING GROUP CONTEXT:\nThe molecule contains protecting groups that have been masked:\nOriginal SMILES: {molecule}\nMasked SMILES: {masked_smiles}\n\nSymbol mapping:\n- '$' represents OMe (methoxy) groups\n- '%' represents OBn (benzyl ether) groups\n- '&' represents OEt (ethoxy) groups\n\nIMPORTANT: In your retrosynthetic analysis:\n1. Return ACTUAL SMILES strings (not the masked symbols) in the 'data' field\n2. Include deprotection steps in your explanations when appropriate\n3. Consider the protecting groups as synthetic handles that may need removal\n4. Suggest specific deprotection conditions:\n   - OMe ($): Acidic hydrolysis (HCl/MeOH, TFA)\n   - OBn (%): Hydrogenolysis (H2/Pd-C), Birch reduction\n   - OEt (&): Acidic hydrolysis (HCl/EtOH), basic hydrolysis (NaOH/EtOH)\n5. When suggesting deprotection steps, use the unmask_protecting_groups_multisymbol() function to convert symbols back to full SMILES\n6. Consider protecting group compatibility and orthogonal deprotection strategies"
-        add_on += protecting_group_context
+    # # Check for protecting groups and add context
+    # # if protect_group_flag.lower() == "true":
+    # #     masked_smiles = mask_protecting_groups_multisymbol(molecule)
+    # # else:
+    # #     masked_smiles = molecule
+    # if masked_smiles != molecule and masked_smiles != "INVALID_SMILES":
+    #     log_message(
+    #         f"Detected protecting groups in molecule: {molecule} -> {masked_smiles}",
+    #         logger)
+    #     protecting_group_context = f"\n\nPROTECTING GROUP CONTEXT:\nThe molecule contains protecting groups that have been masked:\nOriginal SMILES: {molecule}\nMasked SMILES: {masked_smiles}\n\nSymbol mapping:\n- '$' represents OMe (methoxy) groups\n- '%' represents OBn (benzyl ether) groups\n- '&' represents OEt (ethoxy) groups\n\nIMPORTANT: In your retrosynthetic analysis:\n1. Return ACTUAL SMILES strings (not the masked symbols) in the 'data' field\n2. Include deprotection steps in your explanations when appropriate\n3. Consider the protecting groups as synthetic handles that may need removal\n4. Suggest specific deprotection conditions:\n   - OMe ($): Acidic hydrolysis (HCl/MeOH, TFA)\n   - OBn (%): Hydrogenolysis (H2/Pd-C), Birch reduction\n   - OEt (&): Acidic hydrolysis (HCl/EtOH), basic hydrolysis (NaOH/EtOH)\n5. When suggesting deprotection steps, use the unmask_protecting_groups_multisymbol() function to convert symbols back to full SMILES\n6. Consider protecting group compatibility and orthogonal deprotection strategies"
+    #     add_on += protecting_group_context
 
     sys_prompt_final, user_prompt_final, max_completion_tokens = obtain_prompt(
         LLM)


### PR DESCRIPTION
## Description

Fixes a potential issue where the LLM might return a function call to the `unmask_protecting_groups_multisymbol` function.
This might cause multiple unnecessary LLM calls


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings