### PR TITLE
Add LLM provider interfaces

### DIFF
--- a/deepretro/pyproject.toml
+++ b/deepretro/pyproject.toml
@@ -12,16 +12,21 @@ dependencies = [
     "numpy",
     "rdkit",
     "structlog",
-    "xgboost<2.0",  # DeepChem GBDTModel uses XGBoost's sklearn wrapper; >=2.0 has breaking API changes
+    "xgboost<2.0", # DeepChem GBDTModel uses XGBoost's sklearn wrapper; >=2.0 has breaking API changes
     "lightgbm",
     "scikit-learn",
     "pandas",
+    "litellm",
+    "python-dotenv",
+    "langfuse<3",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest",
     "pytest-cov",
+    "ruff",
+    "ty",
 ]
 docs = [
     "sphinx>=8.0",

--- a/deepretro/tests/test_llm_interface.py
+++ b/deepretro/tests/test_llm_interface.py
@@ -46,7 +46,7 @@ def test_infer_provider_classifies_supported_model_identifier_shapes() -> None:
     assert infer_provider("claude-opus-4-6") == "anthropic"
     assert infer_provider("fireworks/deepseek-v3p2") == "deepseek"
     assert infer_provider("deepseek-ai/DeepSeek-R1") == "deepseek"
-    assert infer_provider("custom/model") == "generic"
+    assert infer_provider("custom/model") == "anthropic"
 
 
 def test_create_llm_interface_selects_provider_parser() -> None:

--- a/deepretro/tests/test_llm_interface.py
+++ b/deepretro/tests/test_llm_interface.py
@@ -1,0 +1,252 @@
+"""Focused tests for DeepRetro LLM provider utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from deepretro.utils.llm_helpers import (
+    ChatMessage,
+    build_completion_params,
+    extract_json_payload,
+    infer_provider,
+    split_prompt_mode,
+)
+from deepretro.utils.llm_interface import (
+    LLMRequest,
+    LLMResponse,
+    create_llm_interface,
+    parse_cot_response,
+)
+
+
+def test_split_prompt_mode_only_treats_adv_suffix_as_advanced() -> None:
+    assert split_prompt_mode("openai/gpt-5:adv") == ("openai/gpt-5", "advanced")
+    assert split_prompt_mode("openai/gpt-5") == ("openai/gpt-5", "standard")
+    assert split_prompt_mode("fireworks/deepseek-v3p2:adv") == (
+        "fireworks/deepseek-v3p2",
+        "advanced",
+    )
+    assert split_prompt_mode("anthropic/claude-opus-4-6:adv") == (
+        "anthropic/claude-opus-4-6",
+        "advanced",
+    )
+    assert split_prompt_mode("openai/gpt-5:preview") == (
+        "openai/gpt-5:preview",
+        "standard",
+    )
+
+
+def test_infer_provider_classifies_supported_model_identifier_shapes() -> None:
+    assert infer_provider("openai/gpt-4o-mini") == "openai"
+    assert infer_provider("gpt-unlisted-test-model") == "openai"
+    assert infer_provider("chatgpt-4o-latest") == "openai"
+    assert infer_provider("o3-mini") == "openai"
+    assert infer_provider("anthropic/claude-opus-4-6") == "anthropic"
+    assert infer_provider("claude-opus-4-6") == "anthropic"
+    assert infer_provider("fireworks/deepseek-v3p2") == "deepseek"
+    assert infer_provider("deepseek-ai/DeepSeek-R1") == "deepseek"
+    assert infer_provider("custom/model") == "generic"
+
+
+def test_create_llm_interface_selects_provider_parser() -> None:
+    assert create_llm_interface("openai/gpt-4o-mini").parse_response(
+        '{"data": []}'
+    ) == (200, [], '{"data": []}')
+    assert create_llm_interface("gpt-unlisted-test-model").parse_response(
+        '{"data": []}'
+    ) == (200, [], '{"data": []}')
+    assert create_llm_interface("claude-opus-4-6").parse_response(
+        "<cot><thinking>step</thinking></cot><json>{}</json>"
+    ) == (200, ["step"], "{}")
+    assert create_llm_interface("fireworks/deepseek-v3p2").parse_response(
+        '<think>reason</think><json>{"data": []}</json>'
+    ) == (200, ["reason"], '{"data": []}')
+    assert create_llm_interface("custom/model").parse_response(
+        "<cot><thinking>generic step</thinking></cot><json>{}</json>"
+    ) == (200, ["generic step"], "{}")
+
+
+def test_completion_params_follow_provider_contracts() -> None:
+    messages: list[ChatMessage] = [{"role": "user", "content": "Return OK."}]
+
+    openai_params = build_completion_params(
+        model="openai/gpt-4o-mini",
+        messages=messages,
+        max_completion_tokens=64,
+        temperature=0.2,
+        metadata={"task": "retrosynthesis"},
+    )
+    assert openai_params == {
+        "model": "openai/gpt-4o-mini",
+        "messages": messages,
+        "max_completion_tokens": 64,
+        "temperature": 0.2,
+        "seed": 42,
+        "metadata": {"task": "retrosynthesis"},
+    }
+
+    reasoning = build_completion_params(
+        model="openai/gpt-5",
+        messages=messages,
+        max_completion_tokens=64,
+        temperature=0.2,
+        thinking_effort="high",
+    )
+    assert reasoning["max_completion_tokens"] == 8192
+    assert reasoning["temperature"] == 1
+    assert reasoning["reasoning_effort"] == "high"
+    assert "seed" not in reasoning
+
+    anthropic = build_completion_params(
+        model="claude-opus-4-6",
+        messages=messages,
+        max_completion_tokens=64,
+        temperature=0.2,
+        enable_thinking=False,
+    )
+    assert anthropic == {
+        "model": "claude-opus-4-6",
+        "messages": messages,
+        "max_tokens": 64,
+        "temperature": 0.2,
+    }
+
+    anthropic_reasoning = build_completion_params(
+        model="anthropic/claude-opus-4-6",
+        messages=messages,
+        max_completion_tokens=64,
+        temperature=0.2,
+        enable_thinking=True,
+    )
+    assert anthropic_reasoning == {
+        "model": "anthropic/claude-opus-4-6",
+        "messages": messages,
+        "max_tokens": 8192,
+        "temperature": 1,
+        "reasoning_effort": "medium",
+    }
+
+    deepseek = build_completion_params("fireworks/deepseek-v3p2", messages, 64, 0.2)
+    assert deepseek["model"] == "fireworks_ai/accounts/fireworks/models/deepseek-r1"
+    assert deepseek["max_tokens"] == 64
+    assert "max_completion_tokens" not in deepseek
+
+
+def test_interface_build_messages_preserves_custom_messages_and_fills_prompt() -> None:
+    custom_messages: list[ChatMessage] = [{"role": "user", "content": "Use this"}]
+    request = LLMRequest(
+        molecule="CCO",
+        model="openai/gpt-4o-mini",
+        messages=custom_messages,
+    )
+
+    assert (
+        create_llm_interface(request.model).build_messages(request) is custom_messages
+    )
+
+    messages = create_llm_interface("openai/gpt-4o-mini").build_messages(
+        LLMRequest("CCO", "openai/gpt-4o-mini")
+    )
+
+    assert [message["role"] for message in messages] == ["system", "user"]
+    assert "{target_smiles}" not in messages[1]["content"]
+    assert "CCO" in messages[1]["content"]
+
+
+def test_provider_parsers_extract_payloads_and_preserve_error_codes() -> None:
+    cot_response = "<cot><thinking>step</thinking></cot><json>{}</json>"
+    cot_with_fenced_json = (
+        '<cot><thinking>step</thinking></cot>\n```json\n{"data": []}\n```'
+    )
+    deepseek_response = '<think>reason</think><json>{"data": []}</json>'
+
+    assert parse_cot_response(cot_response) == (200, ["step"], "{}")
+    assert parse_cot_response(cot_with_fenced_json) == (
+        200,
+        ["step"],
+        '{"data": []}',
+    )
+    assert parse_cot_response("missing tags") == (501, [], "")
+    assert create_llm_interface("openai/gpt-4o-mini").parse_response(
+        'prefix {"data": []} suffix'
+    ) == (200, [], '{"data": []}')
+    assert create_llm_interface("openai/gpt-4o-mini").parse_response(
+        "missing json"
+    ) == (502, [], "")
+    assert create_llm_interface("deepseek-ai/DeepSeek-R1").parse_response(
+        deepseek_response
+    ) == (200, ["reason"], '{"data": []}')
+    assert create_llm_interface("deepseek-ai/DeepSeek-R1").parse_response(
+        '{"data": []}'
+    ) == (200, [], '{"data": []}')
+    assert create_llm_interface("deepseek-ai/DeepSeek-R1").parse_response(
+        "missing json"
+    ) == (503, [], "")
+
+
+def test_json_payload_helpers() -> None:
+    assert extract_json_payload('<json>{"data": []}</json>') == '{"data": []}'
+    assert extract_json_payload('```json\n{"data": []}\n```') == '{"data": []}'
+    assert extract_json_payload("prefix [1, 2] suffix") == "[1, 2]"
+    assert extract_json_payload("No JSON here") is None
+
+
+def test_interface_call_wraps_litellm_completion(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeMessage:
+        content = [{"text": "O"}, {"text": "K"}]
+
+    class FakeChoice:
+        message = FakeMessage()
+
+    class FakeResponse:
+        choices = [FakeChoice()]
+
+    def fake_completion(**params: object) -> FakeResponse:
+        captured["params"] = params
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "deepretro.utils.llm_interface.completion",
+        fake_completion,
+    )
+
+    response = create_llm_interface("openai/gpt-4o-mini").call(
+        LLMRequest(
+            molecule="CCO",
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "Return OK"}],
+            max_output_tokens=32,
+        )
+    )
+
+    assert response == LLMResponse(status_code=200, text="OK")
+    assert captured["params"]["model"] == "openai/gpt-4o-mini"
+    assert captured["params"]["messages"] == [{"role": "user", "content": "Return OK"}]
+    assert captured["params"]["max_completion_tokens"] == 32
+
+
+def test_interface_call_returns_error_after_retries(monkeypatch: Any) -> None:
+    attempts = 0
+
+    def fake_completion(**params: object) -> object:
+        nonlocal attempts
+        del params
+        attempts += 1
+        raise RuntimeError("network unavailable")
+
+    monkeypatch.setattr("deepretro.utils.llm_interface.completion", fake_completion)
+
+    response = create_llm_interface("openai/gpt-4o-mini").call(
+        LLMRequest(
+            molecule="CCO",
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "Return OK"}],
+        )
+    )
+
+    assert attempts == 2
+    assert response.status_code == 400
+    assert re.search("network unavailable", response.text)

--- a/deepretro/tests/test_llm_interface.py
+++ b/deepretro/tests/test_llm_interface.py
@@ -86,6 +86,8 @@ def test_completion_params_follow_provider_contracts() -> None:
         "metadata": {"task": "retrosynthesis"},
     }
 
+    # added seperately to test reasoning effort, reasoning requires temperature=1
+    # max_tokens should also be set to something higher for reasoning models
     reasoning = build_completion_params(
         model="openai/gpt-5",
         messages=messages,
@@ -98,6 +100,7 @@ def test_completion_params_follow_provider_contracts() -> None:
     assert reasoning["reasoning_effort"] == "high"
     assert "seed" not in reasoning
 
+    # anthropic models use max_tokens instead of max_completion_tokens
     anthropic = build_completion_params(
         model="claude-opus-4-6",
         messages=messages,
@@ -112,6 +115,8 @@ def test_completion_params_follow_provider_contracts() -> None:
         "temperature": 0.2,
     }
 
+    # added seperately to test reasoning effort, reasoning requires temperature=1,
+    # max_tokens should also be set to something higher for reasoning models
     anthropic_reasoning = build_completion_params(
         model="anthropic/claude-opus-4-6",
         messages=messages,
@@ -127,10 +132,6 @@ def test_completion_params_follow_provider_contracts() -> None:
         "reasoning_effort": "medium",
     }
 
-    deepseek = build_completion_params("fireworks/deepseek-v3p2", messages, 64, 0.2)
-    assert deepseek["model"] == "fireworks_ai/accounts/fireworks/models/deepseek-r1"
-    assert deepseek["max_tokens"] == 64
-    assert "max_completion_tokens" not in deepseek
 
 
 def test_interface_build_messages_preserves_custom_messages_and_fills_prompt() -> None:
@@ -192,61 +193,3 @@ def test_json_payload_helpers() -> None:
     assert extract_json_payload("No JSON here") is None
 
 
-def test_interface_call_wraps_litellm_completion(monkeypatch: Any) -> None:
-    captured: dict[str, Any] = {}
-
-    class FakeMessage:
-        content = [{"text": "O"}, {"text": "K"}]
-
-    class FakeChoice:
-        message = FakeMessage()
-
-    class FakeResponse:
-        choices = [FakeChoice()]
-
-    def fake_completion(**params: object) -> FakeResponse:
-        captured["params"] = params
-        return FakeResponse()
-
-    monkeypatch.setattr(
-        "deepretro.utils.llm_interface.completion",
-        fake_completion,
-    )
-
-    response = create_llm_interface("openai/gpt-4o-mini").call(
-        LLMRequest(
-            molecule="CCO",
-            model="openai/gpt-4o-mini",
-            messages=[{"role": "user", "content": "Return OK"}],
-            max_output_tokens=32,
-        )
-    )
-
-    assert response == LLMResponse(status_code=200, text="OK")
-    assert captured["params"]["model"] == "openai/gpt-4o-mini"
-    assert captured["params"]["messages"] == [{"role": "user", "content": "Return OK"}]
-    assert captured["params"]["max_completion_tokens"] == 32
-
-
-def test_interface_call_returns_error_after_retries(monkeypatch: Any) -> None:
-    attempts = 0
-
-    def fake_completion(**params: object) -> object:
-        nonlocal attempts
-        del params
-        attempts += 1
-        raise RuntimeError("network unavailable")
-
-    monkeypatch.setattr("deepretro.utils.llm_interface.completion", fake_completion)
-
-    response = create_llm_interface("openai/gpt-4o-mini").call(
-        LLMRequest(
-            molecule="CCO",
-            model="openai/gpt-4o-mini",
-            messages=[{"role": "user", "content": "Return OK"}],
-        )
-    )
-
-    assert attempts == 2
-    assert response.status_code == 400
-    assert re.search("network unavailable", response.text)

--- a/deepretro/utils/llm_helpers.py
+++ b/deepretro/utils/llm_helpers.py
@@ -551,6 +551,12 @@ def extract_json_payload(response_text: str) -> str | None:
 
 def is_enabled(flag: str | bool) -> bool:
     """Normalize string and boolean feature flags.
+    
+    Note:
+    -----
+    This function is added for backwards compatibility, ideally we should 
+    not have this as type safety is altered with this, we should remove this 
+    once we make sure type safety is maintained.
 
     Parameters
     ----------

--- a/deepretro/utils/llm_helpers.py
+++ b/deepretro/utils/llm_helpers.py
@@ -10,7 +10,7 @@ from deepretro.utils.variables import DEEPSEEK_MODELS, OPENAI_MODELS
 
 PromptMode = Literal["standard", "advanced"]
 ModelFamily = Literal["deepseek", "openai", "default"]
-ProviderName = Literal["anthropic", "openai", "deepseek", "generic"]
+ProviderName = Literal["anthropic", "openai", "deepseek"]
 ThinkingEffort = Literal["low", "medium", "high", "max"]
 OutputTokenParam = Literal["max_tokens", "max_completion_tokens"]
 
@@ -42,7 +42,7 @@ class ModelSelection:
         Prompt variant selected for the call.
     family : {"deepseek", "openai", "default"}
         Prompt and parser family for the model.
-    provider : {"anthropic", "openai", "deepseek", "generic"}
+    provider : {"anthropic", "openai", "deepseek"}
         Provider inferred from the model name.
     output_token_param : {"max_tokens", "max_completion_tokens"}
         Token-limit keyword expected by the provider.
@@ -219,7 +219,7 @@ def infer_provider(model: str) -> ProviderName:
         return "openai"
     if lower_model.startswith("anthropic/") or "claude" in lower_model:
         return "anthropic"
-    return "generic"
+    return "anthropic"
 
 
 def normalize_completion_model(model: str, provider: ProviderName) -> str:

--- a/deepretro/utils/llm_helpers.py
+++ b/deepretro/utils/llm_helpers.py
@@ -1,0 +1,574 @@
+"""Helper utilities for DeepRetro LLM provider handling."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Literal, TypedDict
+
+from deepretro.utils.variables import DEEPSEEK_MODELS, OPENAI_MODELS
+
+PromptMode = Literal["standard", "advanced"]
+ModelFamily = Literal["deepseek", "openai", "default"]
+ProviderName = Literal["anthropic", "openai", "deepseek", "generic"]
+ThinkingEffort = Literal["low", "medium", "high", "max"]
+OutputTokenParam = Literal["max_tokens", "max_completion_tokens"]
+
+
+class ChatMessage(TypedDict):
+    """Chat message sent to LiteLLM."""
+
+    role: str
+    content: str
+
+
+Pathway = list[str]
+
+MIN_REASONING_OUTPUT_TOKENS = 8192
+PREFERRED_DEEPSEEK_MODEL = "fireworks_ai/accounts/fireworks/models/deepseek-r1"
+
+
+@dataclass(frozen=True)
+class ModelSelection:
+    """Normalized model configuration derived from a model identifier.
+
+    Attributes
+    ----------
+    raw_model : str
+        Original model identifier provided by the caller.
+    completion_model : str
+        Model identifier passed to LiteLLM after alias normalization.
+    prompt_mode : {"standard", "advanced"}
+        Prompt variant selected for the call.
+    family : {"deepseek", "openai", "default"}
+        Prompt and parser family for the model.
+    provider : {"anthropic", "openai", "deepseek", "generic"}
+        Provider inferred from the model name.
+    output_token_param : {"max_tokens", "max_completion_tokens"}
+        Token-limit keyword expected by the provider.
+    supports_reasoning_effort : bool
+        Whether the model supports a ``reasoning_effort`` control.
+    supports_seed : bool
+        Whether deterministic seed should be sent.
+    requires_temperature_one : bool
+        Whether the model should be called with temperature ``1``.
+    """
+
+    raw_model: str
+    completion_model: str
+    prompt_mode: PromptMode
+    family: ModelFamily
+    provider: ProviderName
+    output_token_param: OutputTokenParam
+    supports_reasoning_effort: bool
+    supports_seed: bool
+    requires_temperature_one: bool
+
+
+def split_prompt_mode(model: str) -> tuple[str, PromptMode]:
+    """Split a model identifier from the optional ``:adv`` prompt suffix.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier, optionally suffixed with ``:adv``.
+
+    Returns
+    -------
+    tuple[str, PromptMode]
+        Base model identifier and prompt mode.
+
+    Examples
+    --------
+    >>> split_prompt_mode("openai/gpt-4o-mini:adv")
+    ('openai/gpt-4o-mini', 'advanced')
+    >>> split_prompt_mode("claude-opus-4-6")
+    ('claude-opus-4-6', 'standard')
+    """
+    base_model, separator, suffix = model.rpartition(":")
+    if separator and suffix == "adv":
+        return base_model, "advanced"
+    return model, "standard"
+
+
+def strip_provider_prefix(model: str) -> str:
+    """Return the provider-independent model name when a known prefix exists.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier that may include a LiteLLM provider prefix.
+
+    Returns
+    -------
+    str
+        Model identifier with known ``openai/`` or ``anthropic/`` prefix
+        removed.
+
+    Examples
+    --------
+    >>> strip_provider_prefix("openai/gpt-4o-mini")
+    'gpt-4o-mini'
+    >>> strip_provider_prefix("fireworks_ai/accounts/fireworks/models/deepseek-r1")
+    'fireworks_ai/accounts/fireworks/models/deepseek-r1'
+    """
+    provider, separator, remainder = model.partition("/")
+    if separator and provider in {"openai", "anthropic"}:
+        return remainder
+    return model
+
+
+def looks_like_openai_model(model: str) -> bool:
+    """Return whether a model identifier appears to be an OpenAI model.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` for OpenAI-style model identifiers.
+
+    Examples
+    --------
+    >>> looks_like_openai_model("openai/gpt-4o-mini")
+    True
+    >>> looks_like_openai_model("claude-opus-4-6")
+    False
+    """
+    base_name = strip_provider_prefix(model).lower()
+    return base_name.startswith(("gpt-", "chatgpt-", "o1", "o3", "o4"))
+
+
+def looks_like_openai_reasoning_model(model: str) -> bool:
+    """Return whether a model is an OpenAI reasoning-capable model.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` for OpenAI reasoning-model families.
+
+    Examples
+    --------
+    >>> looks_like_openai_reasoning_model("openai/gpt-5")
+    True
+    >>> looks_like_openai_reasoning_model("openai/gpt-4o-mini")
+    False
+    """
+    base_name = strip_provider_prefix(model).lower()
+    return base_name.startswith(("o1", "o3", "o4", "gpt-5"))
+
+
+def looks_like_anthropic_reasoning_model(model: str) -> bool:
+    """Return whether a model is an Anthropic reasoning-capable model.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` for Anthropic reasoning-model families.
+
+    Examples
+    --------
+    >>> looks_like_anthropic_reasoning_model("anthropic/claude-sonnet-4-6")
+    True
+    >>> looks_like_anthropic_reasoning_model("claude-3-5-haiku-20241022")
+    False
+    """
+    base_name = strip_provider_prefix(model).lower()
+    return base_name.startswith(("claude-opus-4-", "claude-sonnet-4-"))
+
+
+def infer_provider(model: str) -> ProviderName:
+    """Infer the provider from a model identifier.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier to classify.
+
+    Returns
+    -------
+    ProviderName
+        Inferred provider name.
+
+    Examples
+    --------
+    >>> infer_provider("openai/gpt-4o-mini")
+    'openai'
+    >>> infer_provider("claude-opus-4-6")
+    'anthropic'
+    """
+    lower_model = model.lower()
+    if model in DEEPSEEK_MODELS or "deepseek" in lower_model:
+        return "deepseek"
+    if model in OPENAI_MODELS or lower_model.startswith("openai/"):
+        return "openai"
+    if looks_like_openai_model(model):
+        return "openai"
+    if lower_model.startswith("anthropic/") or "claude" in lower_model:
+        return "anthropic"
+    return "generic"
+
+
+def normalize_completion_model(model: str, provider: ProviderName) -> str:
+    """Normalize provider aliases before a LiteLLM completion call.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier supplied by a caller.
+    provider : ProviderName
+        Provider inferred for the model.
+
+    Returns
+    -------
+    str
+        LiteLLM-compatible model identifier.
+
+    Examples
+    --------
+    >>> normalize_completion_model("openai/gpt-4o-mini", "openai")
+    'openai/gpt-4o-mini'
+    >>> normalize_completion_model("fireworks/deepseek-v3p2", "deepseek")
+    'fireworks_ai/accounts/fireworks/models/deepseek-r1'
+    """
+    if provider != "deepseek":
+        return model
+
+    lower_model = model.lower()
+    if lower_model in {
+        "fireworks/deepseek-v3p2",
+        "fireworks_ai/deepseek-v3p2",
+    }:
+        return PREFERRED_DEEPSEEK_MODEL
+    if "deepseek" in lower_model and model not in DEEPSEEK_MODELS:
+        return PREFERRED_DEEPSEEK_MODEL
+    return model
+
+
+def resolve_model_selection(
+    model: str,
+    prompt_mode: PromptMode | None = None,
+) -> ModelSelection:
+    """Resolve provider, prompt, and capability settings for a model.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier, optionally suffixed with ``:adv``.
+    prompt_mode : {"standard", "advanced"}, optional
+        Explicit prompt-mode override.
+
+    Returns
+    -------
+    ModelSelection
+        Normalized model configuration.
+
+    Examples
+    --------
+    >>> selection = resolve_model_selection("openai/gpt-4o-mini:adv")
+    >>> (selection.provider, selection.prompt_mode)
+    ('openai', 'advanced')
+    """
+    completion_model, suffix_prompt_mode = split_prompt_mode(model)
+    provider = infer_provider(completion_model)
+    completion_model = normalize_completion_model(completion_model, provider)
+    resolved_prompt_mode = prompt_mode or suffix_prompt_mode
+
+    if provider == "deepseek":
+        family: ModelFamily = "deepseek"
+    elif provider == "openai":
+        family = "openai"
+    else:
+        family = "default"
+
+    is_openai_reasoning = provider == "openai" and looks_like_openai_reasoning_model(
+        completion_model
+    )
+    is_anthropic_reasoning = (
+        provider == "anthropic"
+        and looks_like_anthropic_reasoning_model(completion_model)
+    )
+    return ModelSelection(
+        raw_model=model,
+        completion_model=completion_model,
+        prompt_mode=resolved_prompt_mode,
+        family=family,
+        provider=provider,
+        output_token_param=(
+            "max_completion_tokens" if provider == "openai" else "max_tokens"
+        ),
+        supports_reasoning_effort=is_openai_reasoning or is_anthropic_reasoning,
+        supports_seed=(provider == "openai") and not is_openai_reasoning,
+        requires_temperature_one=is_openai_reasoning or is_anthropic_reasoning,
+    )
+
+
+def resolve_output_token_limit(
+    selection: ModelSelection,
+    max_output_tokens: int,
+    enable_thinking: bool,
+) -> int:
+    """Return a provider-safe output token budget.
+
+    Parameters
+    ----------
+    selection : ModelSelection
+        Normalized model configuration.
+    max_output_tokens : int
+        Requested output token limit.
+    enable_thinking : bool
+        Whether reasoning controls are enabled.
+
+    Returns
+    -------
+    int
+        Token limit adjusted for reasoning-capable models when needed.
+
+    Examples
+    --------
+    >>> selection = resolve_model_selection("openai/gpt-5")
+    >>> resolve_output_token_limit(selection, 32, enable_thinking=True)
+    8192
+    """
+    if enable_thinking and selection.supports_reasoning_effort:
+        return max(max_output_tokens, MIN_REASONING_OUTPUT_TOKENS)
+    return max_output_tokens
+
+
+def build_completion_params(
+    model: str,
+    messages: list[ChatMessage],
+    max_completion_tokens: int,
+    temperature: float,
+    enable_thinking: bool = True,
+    thinking_effort: ThinkingEffort = "medium",
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Assemble provider-aware keyword arguments for ``litellm.completion``.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier, optionally with a LiteLLM provider prefix.
+    messages : list[ChatMessage]
+        Conversation to send to the model.
+    max_completion_tokens : int
+        Requested maximum output tokens.
+    temperature : float
+        Sampling temperature for providers that allow it. OpenAI reasoning
+        models and Anthropic Claude 4 reasoning-capable models are sent
+        ``temperature=1`` when reasoning controls are enabled.
+    enable_thinking : bool, optional
+        Whether to send reasoning controls for supported models.
+    thinking_effort : {"low", "medium", "high", "max"}, optional
+        Reasoning effort sent to supported models.
+    metadata : dict[str, Any], optional
+        Optional LiteLLM metadata for callbacks.
+
+    Returns
+    -------
+    dict[str, Any]
+        Keyword arguments for ``litellm.completion``.
+
+    Examples
+    --------
+    >>> messages = [{"role": "user", "content": "Reply OK"}]
+    >>> params = build_completion_params("openai/gpt-4o-mini", messages, 16, 0.0)
+    >>> (params["model"], params["max_completion_tokens"], params["seed"])
+    ('openai/gpt-4o-mini', 16, 42)
+    >>> params = build_completion_params("anthropic/claude-sonnet-4-6", messages, 16, 0.2)
+    >>> (params["max_tokens"], params["temperature"], params["reasoning_effort"])
+    (8192, 1, 'medium')
+    """
+    selection = resolve_model_selection(model)
+    output_token_limit = resolve_output_token_limit(
+        selection=selection,
+        max_output_tokens=max_completion_tokens,
+        enable_thinking=enable_thinking,
+    )
+    params: dict[str, Any] = {
+        "model": selection.completion_model,
+        "messages": messages,
+        selection.output_token_param: output_token_limit,
+        "temperature": (
+            1 if selection.requires_temperature_one and enable_thinking else temperature
+        ),
+    }
+
+    if selection.supports_seed:
+        params["seed"] = 42
+    if metadata is not None:
+        params["metadata"] = metadata
+    if enable_thinking and selection.supports_reasoning_effort:
+        params["reasoning_effort"] = thinking_effort
+
+    return params
+
+
+def coerce_response_text(content: Any) -> str:
+    """Convert LiteLLM response content to a plain string.
+
+    Parameters
+    ----------
+    content : Any
+        Response content returned by a LiteLLM message.
+
+    Returns
+    -------
+    str
+        Plain text response content.
+
+    Examples
+    --------
+    >>> coerce_response_text("OK")
+    'OK'
+    >>> coerce_response_text([{"text": "O"}, {"text": "K"}])
+    'OK'
+    """
+    if isinstance(content, str):
+        return content
+    if content is None:
+        return ""
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                text_value = item.get("text")
+                if isinstance(text_value, str):
+                    parts.append(text_value)
+        return "".join(parts)
+    return str(content)
+
+
+def strip_code_fences(text: str) -> str:
+    """Remove one surrounding Markdown code fence from a payload.
+
+    Parameters
+    ----------
+    text : str
+        Text that may be wrapped in a Markdown code fence.
+
+    Returns
+    -------
+    str
+        Unwrapped text when a fence is present, otherwise stripped input text.
+
+    Examples
+    --------
+    >>> strip_code_fences('```json\\n{"data": []}\\n```')
+    '{"data": []}'
+    >>> strip_code_fences('{"data": []}')
+    '{"data": []}'
+    """
+    stripped = text.strip()
+    match = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", stripped, re.DOTALL)
+    return match.group(1).strip() if match else stripped
+
+
+def extract_tag_content(text: str, tag: str) -> str | None:
+    """Extract content between matching XML-like tags.
+
+    Parameters
+    ----------
+    text : str
+        Text containing optional XML-like tags.
+    tag : str
+        Tag name to extract.
+
+    Returns
+    -------
+    str | None
+        Tag body when found, otherwise ``None``.
+
+    Examples
+    --------
+    >>> extract_tag_content("<json>{}</json>", "json")
+    '{}'
+    >>> extract_tag_content("missing", "json") is None
+    True
+    """
+    match = re.search(
+        rf"<{re.escape(tag)}\b[^>]*>\s*(.*?)\s*</{re.escape(tag)}>",
+        text,
+        re.DOTALL,
+    )
+    return match.group(1) if match else None
+
+
+def extract_json_payload(response_text: str) -> str | None:
+    """Extract tagged, fenced, or raw JSON-like payload from model text.
+
+    Parameters
+    ----------
+    response_text : str
+        Raw model response text.
+
+    Returns
+    -------
+    str | None
+        Extracted JSON-like payload, or ``None`` when no payload is found.
+
+    Examples
+    --------
+    >>> extract_json_payload('<json>{"data": []}</json>')
+    '{"data": []}'
+    >>> extract_json_payload('No JSON here') is None
+    True
+    """
+    tagged_json = extract_tag_content(response_text, "json")
+    if tagged_json:
+        return tagged_json
+
+    stripped = strip_code_fences(response_text)
+    if stripped.startswith(("{", "[")) and stripped.endswith(("}", "]")):
+        return stripped
+
+    first_object = stripped.find("{")
+    last_object = stripped.rfind("}")
+    if first_object != -1 and last_object > first_object:
+        return stripped[first_object : last_object + 1]
+
+    first_array = stripped.find("[")
+    last_array = stripped.rfind("]")
+    if first_array != -1 and last_array > first_array:
+        return stripped[first_array : last_array + 1]
+
+    return None
+
+
+def is_enabled(flag: str | bool) -> bool:
+    """Normalize string and boolean feature flags.
+
+    Parameters
+    ----------
+    flag : str or bool
+        Feature flag value.
+
+    Returns
+    -------
+    bool
+        Normalized boolean value.
+
+    Examples
+    --------
+    >>> is_enabled("True")
+    True
+    >>> is_enabled(False)
+    False
+    """
+    if isinstance(flag, bool):
+        return flag
+    return flag.lower() == "true"

--- a/deepretro/utils/llm_interface.py
+++ b/deepretro/utils/llm_interface.py
@@ -439,18 +439,6 @@ class DeepSeekLLM(LLMInterface):
         return 200, thinking_steps, json_content
 
 
-class GenericLLM(AnthropicLLM):
-    """Fallback interface for Claude-style generic providers.
-
-    Examples
-    --------
-    >>> GenericLLM("custom/model").parse_response(
-    ...     "<cot><thinking>x</thinking></cot><json>{}</json>"
-    ... )
-    (200, ['x'], '{}')
-    """
-
-
 def parse_cot_response(response_text: str) -> tuple[int, list[str], str]:
     """Parse Claude-style ``<cot>`` output with a JSON payload.
 
@@ -525,4 +513,4 @@ def create_llm_interface(
         return DeepSeekLLM(model, prompt_mode=prompt_mode)
     if selection.provider == "anthropic":
         return AnthropicLLM(model, prompt_mode=prompt_mode)
-    return GenericLLM(model, prompt_mode=prompt_mode)
+    return AnthropicLLM(model, prompt_mode=prompt_mode)

--- a/deepretro/utils/llm_interface.py
+++ b/deepretro/utils/llm_interface.py
@@ -1,0 +1,528 @@
+"""Provider-specific LLM interfaces for DeepRetro retrosynthesis calls."""
+
+from __future__ import annotations
+
+import re
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import structlog
+from litellm import completion
+
+from deepretro.utils.llm_helpers import (
+    ChatMessage,
+    ModelSelection,
+    PromptMode,
+    ThinkingEffort,
+    build_completion_params,
+    coerce_response_text,
+    extract_json_payload,
+    extract_tag_content,
+    resolve_model_selection,
+)
+from deepretro.utils.utils_molecule import detect_seven_member_rings
+from deepretro.utils.variables import (
+    ADDON_PROMPT_7_MEMBER,
+    SYS_PROMPT,
+    SYS_PROMPT_DEEPSEEK,
+    SYS_PROMPT_OPENAI,
+    SYS_PROMPT_V4,
+    USER_PROMPT,
+    USER_PROMPT_DEEPSEEK,
+    USER_PROMPT_DEEPSEEK_V4,
+    USER_PROMPT_OPENAI,
+    USER_PROMPT_V4,
+)
+
+logger = structlog.get_logger(__name__)
+
+MAX_API_RETRIES = 2
+PROMPT_CONFIG = {
+    ("deepseek", "standard"): (SYS_PROMPT_DEEPSEEK, USER_PROMPT_DEEPSEEK, 16384),
+    ("deepseek", "advanced"): (SYS_PROMPT_V4, USER_PROMPT_DEEPSEEK_V4, 16384),
+    ("openai", "standard"): (SYS_PROMPT_OPENAI, USER_PROMPT_OPENAI, 16384),
+    ("openai", "advanced"): (SYS_PROMPT_OPENAI, USER_PROMPT_OPENAI, 16384),
+    ("default", "standard"): (SYS_PROMPT, USER_PROMPT, 16384),
+    ("default", "advanced"): (SYS_PROMPT_V4, USER_PROMPT_V4, 16384),
+}
+
+
+@dataclass(frozen=True)
+class LLMRequest:
+    """Input state for one LLM completion request.
+
+    Attributes
+    ----------
+    molecule : str
+        Target molecule SMILES.
+    model : str
+        LiteLLM model identifier, optionally suffixed with ``:adv``.
+    temperature : float, optional
+        Sampling temperature.
+    messages : list[ChatMessage], optional
+        Explicit chat messages. When provided, prompt construction is skipped.
+    prompt_mode : {"standard", "advanced"}, optional
+        Prompt-mode override.
+    enable_thinking : bool, optional
+        Whether provider-supported reasoning controls should be sent.
+    thinking_effort : {"low", "medium", "high", "max"}, optional
+        Provider reasoning effort when supported.
+    max_output_tokens : int, optional
+        Output token override.
+
+    Examples
+    --------
+    >>> request = LLMRequest("CCO", "openai/gpt-4o-mini", max_output_tokens=16)
+    >>> (request.molecule, request.temperature, request.enable_thinking)
+    ('CCO', 0.0, True)
+    """
+
+    molecule: str
+    model: str
+    temperature: float = 0.0
+    messages: list[ChatMessage] | None = None
+    prompt_mode: PromptMode | None = None
+    enable_thinking: bool = True
+    thinking_effort: ThinkingEffort = "medium"
+    max_output_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    """Output state from one LLM completion request.
+
+    Attributes
+    ----------
+    status_code : int
+        Status code for the call. ``200`` means success.
+    text : str
+        Response text or final error message.
+
+    Examples
+    --------
+    >>> response = LLMResponse(status_code=200, text="OK")
+    >>> (response.status_code, response.text)
+    (200, 'OK')
+    """
+
+    status_code: int
+    text: str
+
+
+def build_addon_prompt(molecule: str) -> str:
+    """Build additional prompt context for a target molecule.
+
+    Parameters
+    ----------
+    molecule : str
+        Target molecule SMILES.
+
+    Returns
+    -------
+    str
+        Additional prompt text for known chemistry edge cases.
+
+    Examples
+    --------
+    >>> build_addon_prompt("CCO")
+    ''
+    """
+    if detect_seven_member_rings(molecule):
+        logger.debug("Detected seven-membered ring", molecule=molecule)
+        return ADDON_PROMPT_7_MEMBER
+    return ""
+
+
+class LLMInterface(ABC):
+    """Abstract provider interface for LLM completion calls.
+
+    Parameters
+    ----------
+    model : str
+        LiteLLM model identifier.
+    prompt_mode : {"standard", "advanced"}, optional
+        Prompt-mode override.
+
+    Examples
+    --------
+    >>> interface = create_llm_interface("openai/gpt-4o-mini")
+    >>> isinstance(interface, LLMInterface)
+    True
+    """
+
+    def __init__(self, model: str, prompt_mode: PromptMode | None = None) -> None:
+        """Initialize provider selection for a model."""
+        self.selection = resolve_model_selection(model, prompt_mode=prompt_mode)
+
+    def obtain_prompt(self) -> tuple[str, str, int]:
+        """Return the prompt pair and default output-token limit.
+
+        Returns
+        -------
+        tuple[str, str, int]
+            System prompt, user prompt, and default output-token limit.
+
+        Examples
+        --------
+        >>> create_llm_interface("openai/gpt-4o-mini").obtain_prompt()[2]
+        16384
+        """
+        return PROMPT_CONFIG[(self.selection.family, self.selection.prompt_mode)]
+
+    def build_messages(self, request: LLMRequest) -> list[ChatMessage]:
+        """Return caller messages or build the default prompt pair.
+
+        Parameters
+        ----------
+        request : LLMRequest
+            Request state for the call.
+
+        Returns
+        -------
+        list[ChatMessage]
+            Chat messages ready for LiteLLM.
+
+        Examples
+        --------
+        >>> request = LLMRequest("CCO", "openai/gpt-4o-mini")
+        >>> messages = create_llm_interface(request.model).build_messages(request)
+        >>> [message["role"] for message in messages]
+        ['system', 'user']
+        """
+        if request.messages is not None:
+            return request.messages
+
+        sys_prompt, user_prompt, _ = self.obtain_prompt()
+        addon = build_addon_prompt(request.molecule)
+        user_content = user_prompt.replace("{target_smiles}", request.molecule)
+        if addon:
+            user_content = f"{user_content}\n\n{addon}"
+
+        return [
+            {"role": "system", "content": sys_prompt + addon},
+            {"role": "user", "content": user_content},
+        ]
+
+    def build_completion_params(
+        self,
+        request: LLMRequest,
+        messages: list[ChatMessage],
+    ) -> dict[str, object]:
+        """Build provider-aware LiteLLM completion parameters.
+
+        Parameters
+        ----------
+        request : LLMRequest
+            Request state for the call.
+        messages : list[ChatMessage]
+            Chat messages to send.
+
+        Returns
+        -------
+        dict[str, object]
+            Keyword arguments for ``litellm.completion``.
+
+        Examples
+        --------
+        >>> request = LLMRequest("CCO", "openai/gpt-4o-mini", max_output_tokens=16)
+        >>> params = create_llm_interface(request.model).build_completion_params(
+        ...     request,
+        ...     [{"role": "user", "content": "Reply OK"}],
+        ... )
+        >>> params["max_completion_tokens"]
+        16
+        """
+        _, _, default_max_output_tokens = self.obtain_prompt()
+        token_limit = request.max_output_tokens or default_max_output_tokens
+        return build_completion_params(
+            model=self.selection.completion_model,
+            messages=messages,
+            max_completion_tokens=token_limit,
+            temperature=request.temperature,
+            enable_thinking=request.enable_thinking,
+            thinking_effort=request.thinking_effort,
+            metadata={"task": "retrosynthesis"},
+        )
+
+    @abstractmethod
+    def parse_response(self, response_text: str) -> tuple[int, list[str], str]:
+        """Parse provider response text into thinking steps and JSON content.
+
+        Parameters
+        ----------
+        response_text : str
+            Raw model response text.
+
+        Returns
+        -------
+        tuple[int, list[str], str]
+            Status code, visible thinking steps, and JSON payload.
+
+        Examples
+        --------
+        >>> create_llm_interface("openai/gpt-4o-mini").parse_response(
+        ...     '<json>{"data": []}</json>'
+        ... )
+        (200, [], '{"data": []}')
+        """
+
+    def call(self, request: LLMRequest) -> LLMResponse:
+        """Call the provider through LiteLLM.
+
+        Parameters
+        ----------
+        request : LLMRequest
+            Request state for the call.
+
+        Returns
+        -------
+        LLMResponse
+            Status code and response text.
+
+        Examples
+        --------
+        >>> response = create_llm_interface("openai/gpt-4o-mini").call(  # doctest: +SKIP
+        ...     LLMRequest("CCO", "openai/gpt-4o-mini")
+        ... )
+        >>> isinstance(response.text, str)  # doctest: +SKIP
+        True
+        """
+        logger.info(
+            "Calling LLM",
+            model=self.selection.completion_model,
+            molecule=request.molecule,
+        )
+        messages = self.build_messages(request)
+        params = self.build_completion_params(request, messages)
+
+        last_error = ""
+        for attempt in range(1, MAX_API_RETRIES + 1):
+            try:
+                response = completion(**params)
+                content = response.choices[0].message.content
+                response_text = coerce_response_text(content)
+                logger.debug(
+                    "Received LLM response", response_length=len(response_text)
+                )
+                return LLMResponse(status_code=200, text=response_text)
+            except Exception as exc:
+                last_error = str(exc)
+                logger.warning(
+                    "LLM call attempt failed",
+                    attempt=attempt,
+                    max_retries=MAX_API_RETRIES,
+                    model=self.selection.completion_model,
+                    error=str(exc),
+                )
+                if attempt < MAX_API_RETRIES:
+                    time.sleep(0.5)
+
+        logger.error(
+            "All LLM attempts exhausted",
+            max_retries=MAX_API_RETRIES,
+            model=self.selection.completion_model,
+        )
+        return LLMResponse(status_code=400, text=last_error)
+
+
+class AnthropicLLM(LLMInterface):
+    """LLM interface for Anthropic/Claude-compatible responses.
+
+    Examples
+    --------
+    >>> AnthropicLLM("claude-opus-4-6").parse_response(
+    ...     "<cot><thinking>x</thinking></cot><json>{}</json>"
+    ... )
+    (200, ['x'], '{}')
+    """
+
+    def parse_response(self, response_text: str) -> tuple[int, list[str], str]:
+        """Parse Claude-style ``<cot>`` output with a JSON payload.
+
+        Parameters
+        ----------
+        response_text : str
+            Raw Claude-style response text. The response must contain ``<cot>``
+            with one or more ``<thinking>`` entries. JSON may be in ``<json>``
+            tags or in a fenced/raw JSON payload after ``</cot>``.
+
+        Returns
+        -------
+        tuple[int, list[str], str]
+            Status code, thinking steps, and JSON payload.
+
+        Examples
+        --------
+        >>> AnthropicLLM("claude-opus-4-6").parse_response(
+        ...     "<cot><thinking>x</thinking></cot><json>{}</json>"
+        ... )
+        (200, ['x'], '{}')
+        >>> AnthropicLLM("claude-opus-4-6").parse_response(
+        ...     '<cot><thinking>x</thinking></cot>```json\\n{}\\n```'
+        ... )
+        (200, ['x'], '{}')
+        """
+        return parse_cot_response(response_text)
+
+
+class OpenAILLM(LLMInterface):
+    """LLM interface for OpenAI responses.
+
+    Examples
+    --------
+    >>> OpenAILLM("openai/gpt-4o-mini").parse_response('<json>{"data": []}</json>')
+    (200, [], '{"data": []}')
+    """
+
+    def parse_response(self, response_text: str) -> tuple[int, list[str], str]:
+        """Parse OpenAI output into JSON payload content.
+
+        Parameters
+        ----------
+        response_text : str
+            OpenAI response text containing tagged, fenced, or raw JSON.
+
+        Returns
+        -------
+        tuple[int, list[str], str]
+            Status code, empty thinking-step list, and JSON payload.
+
+        Examples
+        --------
+        >>> OpenAILLM("openai/gpt-4o-mini").parse_response('<json>{"data": []}</json>')
+        (200, [], '{"data": []}')
+        """
+        json_content = extract_json_payload(response_text)
+        if not json_content:
+            return 502, [], ""
+        return 200, [], json_content
+
+
+class DeepSeekLLM(LLMInterface):
+    """LLM interface for DeepSeek responses.
+
+    Examples
+    --------
+    >>> DeepSeekLLM("deepseek-ai/DeepSeek-R1").parse_response(
+    ...     '<think>x</think><json>{"data": []}</json>'
+    ... )
+    (200, ['x'], '{"data": []}')
+    """
+
+    def parse_response(self, response_text: str) -> tuple[int, list[str], str]:
+        """Parse DeepSeek output into optional thinking and JSON payload content.
+
+        Parameters
+        ----------
+        response_text : str
+            DeepSeek response text containing optional ``<think>`` content and
+            tagged, fenced, or raw JSON.
+
+        Returns
+        -------
+        tuple[int, list[str], str]
+            Status code, optional thinking steps, and JSON payload.
+
+        Examples
+        --------
+        >>> DeepSeekLLM("deepseek-ai/DeepSeek-R1").parse_response(
+        ...     '<think>x</think><json>{"data": []}</json>'
+        ... )
+        (200, ['x'], '{"data": []}')
+        """
+        thinking_content = extract_tag_content(response_text, "think")
+        json_content = extract_json_payload(response_text)
+        if not json_content:
+            return 503, [], ""
+        thinking_steps = [thinking_content] if thinking_content else []
+        return 200, thinking_steps, json_content
+
+
+class GenericLLM(AnthropicLLM):
+    """Fallback interface for Claude-style generic providers.
+
+    Examples
+    --------
+    >>> GenericLLM("custom/model").parse_response(
+    ...     "<cot><thinking>x</thinking></cot><json>{}</json>"
+    ... )
+    (200, ['x'], '{}')
+    """
+
+
+def parse_cot_response(response_text: str) -> tuple[int, list[str], str]:
+    """Parse Claude-style ``<cot>`` output with a JSON payload.
+
+    Parameters
+    ----------
+    response_text : str
+        Raw model response containing ``<cot>`` thinking content and either a
+        ``<json>`` payload or a fenced/raw JSON payload after ``</cot>``.
+
+    Returns
+    -------
+    tuple[int, list[str], str]
+        Status code, extracted thinking steps, and JSON payload.
+
+    Examples
+    --------
+    >>> parse_cot_response("<cot><thinking>x</thinking></cot><json>{}</json>")
+    (200, ['x'], '{}')
+    >>> parse_cot_response('<cot><thinking>x</thinking></cot>```json\\n{}\\n```')
+    (200, ['x'], '{}')
+    """
+    cot_content = extract_tag_content(response_text, "cot")
+    json_content = extract_tag_content(response_text, "json")
+    if not json_content:
+        response_after_cot = response_text.split("</cot>", maxsplit=1)[-1]
+        json_content = extract_json_payload(response_after_cot)
+    if not cot_content or not json_content:
+        return 501, [], ""
+
+    thinking_steps = [
+        match.group(1)
+        for match in re.finditer(
+            r"<thinking[^>]*>(.*?)</thinking>",
+            cot_content,
+            re.DOTALL,
+        )
+        if match.group(1).strip()
+    ]
+    if not thinking_steps:
+        return 501, [], ""
+
+    return 200, thinking_steps, json_content
+
+
+def create_llm_interface(
+    model: str,
+    prompt_mode: PromptMode | None = None,
+) -> LLMInterface:
+    """Create a provider-specific LLM interface.
+
+    Parameters
+    ----------
+    model : str
+        LiteLLM model identifier.
+    prompt_mode : {"standard", "advanced"}, optional
+        Prompt-mode override.
+
+    Returns
+    -------
+    LLMInterface
+        Provider-specific interface instance.
+
+    Examples
+    --------
+    >>> type(create_llm_interface("openai/gpt-4o-mini")).__name__
+    'OpenAILLM'
+    """
+    selection: ModelSelection = resolve_model_selection(model, prompt_mode=prompt_mode)
+    if selection.provider == "openai":
+        return OpenAILLM(model, prompt_mode=prompt_mode)
+    if selection.provider == "deepseek":
+        return DeepSeekLLM(model, prompt_mode=prompt_mode)
+    if selection.provider == "anthropic":
+        return AnthropicLLM(model, prompt_mode=prompt_mode)
+    return GenericLLM(model, prompt_mode=prompt_mode)


### PR DESCRIPTION
## Summary

- Add LiteLLM dependency metadata for LLM-backed utilities.
- Add provider-aware model selection, completion parameter construction, and response parsing helpers.
- Add OpenAI, Anthropic, DeepSeek, and generic LLM interface implementations with focused tests.

docs are added in #203 

## Stack

First PR in the LLM split. Independent against `main`.