### PR TITLE
Add LLM retrosynthesis pipeline

### DIFF
--- a/deepretro/tests/test_llm.py
+++ b/deepretro/tests/test_llm.py
@@ -1,0 +1,250 @@
+"""Focused tests for DeepRetro public LLM utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+
+import pytest
+
+from deepretro.utils import llm
+from deepretro.utils.llm import (
+    build_messages,
+    call_LLM,
+    llm_pipeline,
+    parse_cot_response,
+    parse_deepseek_response,
+    parse_openai_response,
+    parse_response,
+    split_cot_json,
+    split_json_deepseek,
+    split_json_master,
+    split_json_openAI,
+    validate_split_json,
+)
+from deepretro.utils.llm_helpers import ChatMessage, PromptMode
+from deepretro.utils.llm_interface import LLMRequest, LLMResponse
+
+LIVE_TEST_MOLECULE = "CC(=O)Oc1ccccc1C(=O)O"
+
+
+def test_build_messages_preserves_custom_messages_and_fills_default_prompt() -> None:
+    custom_messages: list[ChatMessage] = [{"role": "user", "content": "Use this"}]
+
+    assert (
+        build_messages("CCO", "openai/gpt-4o-mini", messages=custom_messages)
+        is custom_messages
+    )
+
+    messages = build_messages("CCO", "openai/gpt-4o-mini", addon="Extra constraint")
+
+    assert [message["role"] for message in messages] == ["system", "user"]
+    assert "{target_smiles}" not in messages[1]["content"]
+    assert "CCO" in messages[1]["content"]
+    assert messages[1]["content"].endswith("Extra constraint")
+
+
+def test_public_parsers_extract_payloads_and_preserve_error_codes() -> None:
+    cot_response = "<cot><thinking>step</thinking></cot><json>{}</json>"
+    cot_with_fenced_json = (
+        '<cot><thinking>step</thinking></cot>\n```json\n{"data": []}\n```'
+    )
+    deepseek_response = '<think>reason</think><json>{"data": []}</json>'
+
+    assert parse_cot_response(cot_response) == (200, ["step"], "{}")
+    assert parse_cot_response(cot_with_fenced_json) == (
+        200,
+        ["step"],
+        '{"data": []}',
+    )
+    assert parse_cot_response("missing tags") == (501, [], "")
+    assert parse_openai_response('prefix {"data": []} suffix') == (
+        200,
+        [],
+        '{"data": []}',
+    )
+    assert parse_openai_response("missing json") == (502, [], "")
+    assert parse_deepseek_response(deepseek_response) == (
+        200,
+        ["reason"],
+        '{"data": []}',
+    )
+    assert parse_deepseek_response('{"data": []}') == (200, [], '{"data": []}')
+    assert parse_deepseek_response("missing json") == (503, [], "")
+
+
+def test_backward_compatible_parser_wrappers_delegate_to_provider_parsers() -> None:
+    cot_response = "<cot><thinking>step</thinking></cot><json>{}</json>"
+    deepseek_response = '<think>reason</think><json>{"data": []}</json>'
+
+    assert split_cot_json(cot_response) == (200, ["step"], "{}")
+    assert split_json_openAI('```json\n{"data": []}\n```') == (200, '{"data": []}')
+    assert split_json_deepseek(deepseek_response) == (
+        200,
+        ["reason"],
+        '{"data": []}',
+    )
+    assert split_json_master('{"data": []}', "openai/gpt-4o-mini") == (
+        200,
+        [],
+        '{"data": []}',
+    )
+    assert parse_response(cot_response, "claude-opus-4-6") == (200, ["step"], "{}")
+
+
+def test_validate_split_json_returns_aligned_typed_pipeline_data() -> None:
+    payload = (
+        '{"data": [["CCO"], ["CCN"]], "explanation": ["ethanol", "ethylamine"], '
+        '"confidence_scores": [1, "0.5"]}'
+    )
+
+    assert validate_split_json(payload) == (
+        200,
+        [["CCO"], ["CCN"]],
+        ["ethanol", "ethylamine"],
+        [1.0, 0.5],
+    )
+    assert validate_split_json("{bad json") == (504, [], [], [])
+    assert validate_split_json('{"data": [["CCO"]]}') == (504, [], [], [])
+
+
+def test_call_llm_builds_request_for_selected_interface(monkeypatch: Any) -> None:
+    captured: dict[str, LLMRequest] = {}
+
+    class FakeInterface:
+        def call(self, request: LLMRequest) -> LLMResponse:
+            captured["request"] = request
+            return LLMResponse(status_code=200, text="OK")
+
+    monkeypatch.setattr(
+        llm, "create_llm_interface", lambda *args, **kwargs: FakeInterface()
+    )
+
+    status, text = call_LLM(
+        molecule="CCO",
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "Return OK"}],
+        prompt_mode="advanced",
+        enable_thinking=False,
+        max_output_tokens=32,
+    )
+
+    assert (status, text) == (200, "OK")
+    assert captured["request"] == LLMRequest(
+        molecule="CCO",
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "Return OK"}],
+        temperature=0.0,
+        prompt_mode="advanced",
+        enable_thinking=False,
+        max_output_tokens=32,
+    )
+
+
+def assert_retro_response_is_tagged_and_valid(
+    response_text: str,
+    model: str,
+) -> None:
+    assert "<cot>" in response_text
+    assert "</cot>" in response_text
+    assert re.search(r"<thinking\b[^>]*>", response_text)
+    assert "</thinking>" in response_text
+
+    parse_status, thinking_steps, json_content = parse_response(response_text, model)
+    assert parse_status == 200, response_text[:500]
+    assert thinking_steps
+
+    parsed_json = json.loads(json_content)
+    assert {"data", "explanation", "confidence_scores"} <= set(parsed_json)
+
+    validation_status, pathways, explanations, confidence = validate_split_json(
+        json_content
+    )
+    assert validation_status == 200
+    assert pathways
+    assert len(pathways) == len(explanations) == len(confidence)
+    assert all(isinstance(pathway, list) and pathway for pathway in pathways)
+    assert all(
+        isinstance(smiles, str) and smiles for pathway in pathways for smiles in pathway
+    )
+    assert all(0 <= score <= 1 for score in confidence)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("prompt_mode", ["standard", "advanced"])
+def test_live_anthropic_retrosynthesis_prompt_returns_parseable_tagged_json(
+    prompt_mode: PromptMode,
+) -> None:
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        pytest.skip("ANTHROPIC_API_KEY is not configured")
+
+    model = os.getenv(
+        "DEEPRETRO_TEST_ANTHROPIC_MODEL",
+        "anthropic/claude-sonnet-4-6:adv",
+    )
+
+    status, response_text = call_LLM(
+        molecule=LIVE_TEST_MOLECULE,
+        model=model,
+        prompt_mode=prompt_mode,
+        max_output_tokens=8192,
+        enable_thinking=False,
+    )
+
+    assert status == 200, response_text[:500]
+    assert_retro_response_is_tagged_and_valid(response_text, model)
+
+
+def test_llm_pipeline_falls_back_from_deepseek_after_failed_attempt(
+    monkeypatch: Any,
+) -> None:
+    created_models: list[str] = []
+
+    class FakeInterface:
+        def __init__(self, model: str) -> None:
+            self.model = model
+
+        def call(self, request: LLMRequest) -> LLMResponse:
+            if request.model == "deepseek-ai/DeepSeek-R1":
+                return LLMResponse(status_code=400, text="unavailable")
+            return LLMResponse(
+                status_code=200,
+                text="<cot><thinking>step</thinking></cot>"
+                '<json>{"data": [["CCO"]], "explanation": ["fallback"], '
+                '"confidence_scores": [0.7]}</json>',
+            )
+
+        def parse_response(self, response_text: str) -> tuple[int, list[str], str]:
+            assert response_text.startswith("<cot>")
+            return (
+                200,
+                ["step"],
+                '{"data": [["CCO"]], "explanation": ["fallback"], '
+                '"confidence_scores": [0.7]}',
+            )
+
+    def fake_create_interface(model: str, **kwargs: object) -> FakeInterface:
+        del kwargs
+        created_models.append(model)
+        return FakeInterface(model)
+
+    monkeypatch.setattr(llm, "create_llm_interface", fake_create_interface)
+    monkeypatch.setattr(
+        llm,
+        "validity_check",
+        lambda molecule, pathways, explanations, confidence: (
+            pathways,
+            explanations,
+            confidence,
+        ),
+    )
+
+    assert llm_pipeline(
+        molecule="CCO",
+        model="deepseek-ai/DeepSeek-R1",
+        max_output_tokens=128,
+        enable_thinking=False,
+    ) == ([["CCO"]], ["fallback"], [0.7])
+    assert created_models[:2] == ["deepseek-ai/DeepSeek-R1", llm.FALLBACK_MODEL]

--- a/deepretro/utils/llm.py
+++ b/deepretro/utils/llm.py
@@ -1,0 +1,644 @@
+"""LLM-based single-step retrosynthesis helpers.
+
+This module calls chat-completion LLMs through LiteLLM, parses tagged model
+responses, and filters candidate precursor pathways. Provider-specific model
+normalization lives in ``deepretro.utils.llm_helpers`` and provider-specific
+prompt/call/parse behavior lives in ``deepretro.utils.llm_interface`` so the
+public pipeline stays focused on the retrosynthesis workflow.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Any, cast
+
+import litellm
+import structlog
+from dotenv import load_dotenv
+
+from deepretro.algorithms.hallucination_checker import calculate_hallucination_score
+from deepretro.algorithms.stability_checker import check_molecule_stability
+from deepretro.utils.llm_helpers import (
+    ChatMessage,
+    Pathway,
+    PromptMode,
+    ThinkingEffort,
+    is_enabled,
+    resolve_model_selection,
+)
+from deepretro.utils.llm_interface import (
+    LLMRequest,
+    build_addon_prompt as build_addon_prompt,
+    create_llm_interface,
+    parse_cot_response as interface_parse_cot_response,
+)
+from deepretro.utils.utils_molecule import validity_check
+
+load_dotenv()
+
+litellm.success_callback = ["langfuse"]
+litellm.drop_params = True
+
+logger = structlog.get_logger(__name__)
+
+TEMPERATURE_STEP = 0.1
+FALLBACK_MODEL = "claude-opus-4-6"
+STABLE_ASSESSMENTS = {"Likely stable", "Moderately stable"}
+HALLUCINATION_SEVERITIES = {"low", "medium"}
+
+
+def obtain_prompt(
+    model: str,
+    prompt_mode: PromptMode | None = None,
+) -> tuple[str, str, int]:
+    """Select the prompt pair and default output-token limit for a model.
+
+    Parameters
+    ----------
+    model : str
+        Model identifier, optionally with ``:adv``.
+    prompt_mode : {"standard", "advanced"}, optional
+        Explicit prompt-mode override. When omitted, ``:adv`` is honored.
+
+    Returns
+    -------
+    tuple[str, str, int]
+        System prompt, user prompt, and default output-token limit.
+
+    Examples
+    --------
+    >>> _, _, max_tokens = obtain_prompt("openai/gpt-4o-mini")
+    >>> max_tokens
+    16384
+    """
+    return create_llm_interface(model, prompt_mode=prompt_mode).obtain_prompt()
+
+
+def build_messages(
+    molecule: str,
+    model: str,
+    addon: str = "",
+    messages: list[ChatMessage] | None = None,
+    prompt_mode: PromptMode | None = None,
+) -> list[ChatMessage]:
+    """Return caller-provided messages or build the default prompt pair.
+
+    Parameters
+    ----------
+    molecule : str
+        Target molecule SMILES.
+    model : str
+        LiteLLM model identifier used for prompt selection.
+    addon : str, optional
+        Additional context appended to the prompt.
+    messages : list[ChatMessage], optional
+        Caller-provided messages. When provided, these are returned unchanged.
+    prompt_mode : {"standard", "advanced"}, optional
+        Prompt-mode override.
+
+    Returns
+    -------
+    list[ChatMessage]
+        Chat messages ready for ``litellm.completion``.
+
+    Examples
+    --------
+    >>> messages = build_messages("CCO", "openai/gpt-4o-mini")
+    >>> [message["role"] for message in messages]
+    ['system', 'user']
+    >>> custom = [{"role": "user", "content": "Reply OK"}]
+    >>> build_messages("CCO", "openai/gpt-4o-mini", messages=custom) is custom
+    True
+    """
+    request = LLMRequest(
+        molecule=molecule,
+        model=model,
+        messages=messages,
+        prompt_mode=prompt_mode,
+    )
+    built_messages = create_llm_interface(
+        model, prompt_mode=prompt_mode
+    ).build_messages(request)
+    if messages is not None or not addon:
+        return built_messages
+    return [
+        built_messages[0],
+        {"role": "user", "content": f"{built_messages[1]['content']}\n\n{addon}"},
+    ]
+
+
+def call_LLM(
+    molecule: str,
+    model: str = "claude-opus-4-6",
+    temperature: float = 0.0,
+    messages: list[ChatMessage] | None = None,
+    prompt_mode: PromptMode | None = None,
+    enable_thinking: bool = True,
+    thinking_effort: ThinkingEffort = "medium",
+    max_output_tokens: int | None = None,
+) -> tuple[int, str]:
+    """Call an LLM for single-step retrosynthesis.
+
+    Parameters
+    ----------
+    molecule : str
+        Target molecule SMILES.
+    model : str, optional
+        LiteLLM model identifier, optionally with ``:adv``.
+    temperature : float, optional
+        Sampling temperature.
+    messages : list[ChatMessage], optional
+        Explicit chat messages. When provided, default prompt construction is
+        skipped.
+    prompt_mode : {"standard", "advanced"}, optional
+        Prompt-mode override.
+    enable_thinking : bool, optional
+        Whether provider-supported reasoning controls should be sent.
+    thinking_effort : {"low", "medium", "high", "max"}, optional
+        Provider reasoning effort when supported.
+    max_output_tokens : int, optional
+        Output token override. Defaults to the selected prompt configuration.
+
+    Returns
+    -------
+    tuple[int, str]
+        ``(status_code, response_text)``. ``400`` indicates the API call failed
+        after retries.
+
+    Examples
+    --------
+    >>> status, response_text = call_LLM(  # doctest: +SKIP
+    ...     "CCO",
+    ...     model="openai/gpt-4o-mini",
+    ...     max_output_tokens=1024,
+    ... )
+    >>> isinstance(status, int) and isinstance(response_text, str)  # doctest: +SKIP
+    True
+    """
+    interface = create_llm_interface(model, prompt_mode=prompt_mode)
+    request = LLMRequest(
+        molecule=molecule,
+        model=model,
+        messages=messages,
+        temperature=temperature,
+        prompt_mode=prompt_mode,
+        enable_thinking=enable_thinking,
+        thinking_effort=thinking_effort,
+        max_output_tokens=max_output_tokens,
+    )
+    response = interface.call(request)
+    return response.status_code, response.text
+
+
+def parse_cot_response(response_text: str) -> tuple[int, list[str], str]:
+    """Parse Claude-style ``<cot>`` output with a JSON payload.
+
+    Parameters
+    ----------
+    response_text : str
+        Raw model response containing ``<cot>`` thinking content and either a
+        ``<json>`` payload or a fenced/raw JSON payload after ``</cot>``.
+
+    Returns
+    -------
+    tuple[int, list[str], str]
+        Status code, extracted thinking steps, and JSON payload.
+
+    Examples
+    --------
+    >>> text = "<cot><thinking>step</thinking></cot><json>{}</json>"
+    >>> parse_cot_response(text)
+    (200, ['step'], '{}')
+    >>> parse_cot_response('<cot><thinking>x</thinking></cot>```json\\n{}\\n```')
+    (200, ['x'], '{}')
+    """
+    return interface_parse_cot_response(response_text)
+
+
+def parse_openai_response(response_text: str) -> tuple[int, list[str], str]:
+    """Parse OpenAI output into JSON payload content.
+
+    Parameters
+    ----------
+    response_text : str
+        OpenAI response text containing tagged, fenced, or raw JSON.
+
+    Returns
+    -------
+    tuple[int, list[str], str]
+        Status code, empty thinking-step list, and JSON payload.
+
+    Examples
+    --------
+    >>> parse_openai_response('<json>{"data": []}</json>')
+    (200, [], '{"data": []}')
+    """
+    return create_llm_interface("openai/gpt-4o-mini").parse_response(response_text)
+
+
+def parse_deepseek_response(response_text: str) -> tuple[int, list[str], str]:
+    """Parse DeepSeek output into optional thinking and JSON payload content.
+
+    Parameters
+    ----------
+    response_text : str
+        DeepSeek response text containing optional ``<think>`` content and JSON.
+
+    Returns
+    -------
+    tuple[int, list[str], str]
+        Status code, optional thinking steps, and JSON payload.
+
+    Examples
+    --------
+    >>> parse_deepseek_response('<think>step</think><json>{"data": []}</json>')
+    (200, ['step'], '{"data": []}')
+    """
+    return create_llm_interface("deepseek-ai/DeepSeek-R1").parse_response(response_text)
+
+
+def parse_response(response_text: str, model: str) -> tuple[int, list[str], str]:
+    """Parse model output into status, visible thinking steps, and JSON content.
+
+    Parameters
+    ----------
+    response_text : str
+        Raw text returned by the LLM.
+    model : str
+        Model identifier used for the request.
+
+    Returns
+    -------
+    tuple[int, list[str], str]
+        Status code, visible thinking steps, and JSON payload.
+
+    Examples
+    --------
+    >>> parse_response('<json>{"data": []}</json>', "openai/gpt-4o-mini")
+    (200, [], '{"data": []}')
+    """
+    interface = create_llm_interface(model)
+    try:
+        return interface.parse_response(response_text)
+    except Exception as exc:
+        logger.error(
+            "Error parsing LLM response",
+            family=interface.selection.family,
+            error=str(exc),
+        )
+        return 505, [], ""
+
+
+def split_cot_json(response_text: str) -> tuple[int, list[str], str]:
+    """Backward-compatible wrapper for parsing Claude-style responses.
+
+    Parameters
+    ----------
+    response_text : str
+        Raw Claude-style response text.
+
+    Returns
+    -------
+    tuple[int, list[str], str]
+        Status code, thinking steps, and JSON payload.
+
+    Examples
+    --------
+    >>> split_cot_json("<cot><thinking>x</thinking></cot><json>{}</json>")
+    (200, ['x'], '{}')
+    """
+    return parse_cot_response(response_text)
+
+
+def split_json_openAI(response_text: str) -> tuple[int, str]:
+    """Backward-compatible wrapper for parsing OpenAI responses.
+
+    Parameters
+    ----------
+    response_text : str
+        OpenAI response text containing JSON.
+
+    Returns
+    -------
+    tuple[int, str]
+        Status code and JSON payload.
+
+    Examples
+    --------
+    >>> split_json_openAI('<json>{"data": []}</json>')
+    (200, '{"data": []}')
+    """
+    status, _, json_content = parse_openai_response(response_text)
+    return status, json_content
+
+
+def split_json_deepseek(response_text: str) -> tuple[int, list[str], str]:
+    """Backward-compatible wrapper for parsing DeepSeek responses.
+
+    Parameters
+    ----------
+    response_text : str
+        DeepSeek response text containing optional thinking and JSON.
+
+    Returns
+    -------
+    tuple[int, list[str], str]
+        Status code, optional thinking steps, and JSON payload.
+
+    Examples
+    --------
+    >>> split_json_deepseek('<think>x</think><json>{"data": []}</json>')
+    (200, ['x'], '{"data": []}')
+    """
+    return parse_deepseek_response(response_text)
+
+
+def split_json_master(response_text: str, model: str) -> tuple[int, list[str], str]:
+    """Backward-compatible wrapper for provider-aware response parsing.
+
+    Parameters
+    ----------
+    response_text : str
+        Raw model response text.
+    model : str
+        Model identifier used to select the parser.
+
+    Returns
+    -------
+    tuple[int, list[str], str]
+        Status code, visible thinking steps, and JSON payload.
+
+    Examples
+    --------
+    >>> split_json_master('<json>{"data": []}</json>', "openai/gpt-4o-mini")
+    (200, [], '{"data": []}')
+    """
+    return parse_response(response_text, model)
+
+
+def validate_split_json(
+    json_content: str,
+) -> tuple[int, list[Pathway], list[str], list[float]]:
+    """Parse JSON-like response content into candidate pathways.
+
+    Parameters
+    ----------
+    json_content : str
+        JSON object containing ``data``, ``explanation``, and
+        ``confidence_scores``.
+
+    Returns
+    -------
+    tuple[int, list[Pathway], list[str], list[float]]
+        Status code, pathways, explanations, and confidence scores.
+
+    Examples
+    --------
+    >>> validate_split_json(
+    ...     '{"data": [["CCO"]], "explanation": ["demo"], "confidence_scores": [1]}'
+    ... )
+    (200, [['CCO']], ['demo'], [1.0])
+    """
+    try:
+        result = cast(dict[str, Any], ast.literal_eval(json_content))
+        pathways = cast(list[Pathway], result["data"])
+        explanations = cast(list[str], result["explanation"])
+        confidence = [float(value) for value in result["confidence_scores"]]
+        return 200, pathways, explanations, confidence
+    except Exception as exc:
+        logger.error("Error parsing JSON response", error=str(exc))
+        return 504, [], [], []
+
+
+def filter_stable_pathways(pathways: list[Pathway]) -> list[Pathway]:
+    """Keep pathways whose molecules pass the heuristic stability checker.
+
+    Parameters
+    ----------
+    pathways : list[Pathway]
+        Candidate precursor pathways.
+
+    Returns
+    -------
+    list[Pathway]
+        Pathways whose molecules are assessed as stable enough to keep.
+
+    Examples
+    --------
+    >>> filter_stable_pathways([["CCO"]])
+    [['CCO']]
+    """
+    stable_pathways: list[Pathway] = []
+    for pathway in pathways:
+        if all(
+            str(check_molecule_stability(smiles).get("assessment", "Unknown"))
+            in STABLE_ASSESSMENTS
+            for smiles in pathway
+        ):
+            stable_pathways.append(pathway)
+    return stable_pathways
+
+
+def filter_hallucination_pathways(
+    molecule: str,
+    pathways: list[Pathway],
+) -> list[Pathway]:
+    """Keep pathways with low or medium hallucination severity.
+
+    Parameters
+    ----------
+    molecule : str
+        Target molecule SMILES.
+    pathways : list[Pathway]
+        Candidate precursor pathways.
+
+    Returns
+    -------
+    list[Pathway]
+        Pathways whose hallucination severity is acceptable.
+
+    Examples
+    --------
+    >>> filter_hallucination_pathways("CCO", [["CCO"]])
+    [['CCO']]
+    """
+    filtered_pathways: list[Pathway] = []
+    for pathway in pathways:
+        combined_smiles = ".".join(pathway)
+        report = calculate_hallucination_score(combined_smiles, molecule)
+        severity = str(report.get("severity", "critical"))
+        if severity in HALLUCINATION_SEVERITIES:
+            filtered_pathways.append(pathway)
+    return filtered_pathways
+
+
+def filter_metadata_by_pathways(
+    retained_pathways: list[Pathway],
+    pathways: list[Pathway],
+    explanations: list[str],
+    confidence: list[float],
+) -> tuple[list[Pathway], list[str], list[float]]:
+    """Keep explanations and confidence aligned with filtered pathways.
+
+    Parameters
+    ----------
+    retained_pathways : list[Pathway]
+        Filtered pathways to retain.
+    pathways : list[Pathway]
+        Original pathway order.
+    explanations : list[str]
+        Original explanations aligned with ``pathways``.
+    confidence : list[float]
+        Original confidence scores aligned with ``pathways``.
+
+    Returns
+    -------
+    tuple[list[Pathway], list[str], list[float]]
+        Retained pathways with matching explanations and confidence scores.
+
+    Examples
+    --------
+    >>> filter_metadata_by_pathways([["B"]], [["A"], ["B"]], ["a", "b"], [0.1, 0.9])
+    ([['B']], ['b'], [0.9])
+    """
+    retained_explanations: list[str] = []
+    retained_confidence: list[float] = []
+    available = list(zip(pathways, explanations, confidence))
+
+    for retained_pathway in retained_pathways:
+        for index, (pathway, explanation, score) in enumerate(available):
+            if pathway == retained_pathway:
+                retained_explanations.append(explanation)
+                retained_confidence.append(score)
+                available.pop(index)
+                break
+
+    return retained_pathways, retained_explanations, retained_confidence
+
+
+def llm_pipeline(
+    molecule: str,
+    model: str = "claude-opus-4-6",
+    messages: list[ChatMessage] | None = None,
+    stability_check: str | bool = "False",
+    hallucination_check: str | bool = "False",
+    prompt_mode: PromptMode | None = None,
+    enable_thinking: bool = True,
+    max_output_tokens: int | None = None,
+) -> tuple[list[Pathway], list[str], list[float]]:
+    """Run the end-to-end single-step retrosynthesis LLM pipeline.
+
+    Parameters
+    ----------
+    molecule : str
+        Target molecule SMILES.
+    model : str, optional
+        LiteLLM model identifier, optionally with ``:adv``.
+    messages : list[ChatMessage], optional
+        Explicit chat messages for the call.
+    stability_check : str or bool, optional
+        Whether to run the heuristic stability filter.
+    hallucination_check : str or bool, optional
+        Whether to run the heuristic hallucination filter.
+    prompt_mode : {"standard", "advanced"}, optional
+        Prompt-mode override.
+    enable_thinking : bool, optional
+        Whether provider-supported reasoning controls should be sent.
+    max_output_tokens : int, optional
+        Output token override for each LLM call.
+
+    Returns
+    -------
+    tuple[list[Pathway], list[str], list[float]]
+        Valid pathways, explanations, and confidence scores.
+
+    Examples
+    --------
+    >>> pathways, explanations, confidence = llm_pipeline(  # doctest: +SKIP
+    ...     "CCO",
+    ...     model="openai/gpt-4o-mini",
+    ...     max_output_tokens=2048,
+    ... )
+    >>> isinstance(pathways, list) and isinstance(explanations, list)  # doctest: +SKIP
+    True
+    """
+    run_stability = is_enabled(stability_check)
+    run_hallucination = is_enabled(hallucination_check)
+    max_attempts = 15 if (run_stability or run_hallucination) else 6
+
+    for attempt in range(max_attempts):
+        temperature = round(attempt * TEMPERATURE_STEP, 2)
+        current_model = model
+        if resolve_model_selection(model).family == "deepseek" and attempt > 0:
+            current_model = FALLBACK_MODEL
+        interface = create_llm_interface(current_model, prompt_mode=prompt_mode)
+
+        response = interface.call(
+            LLMRequest(
+                molecule=molecule,
+                model=current_model,
+                messages=messages,
+                temperature=temperature,
+                prompt_mode=prompt_mode,
+                enable_thinking=enable_thinking,
+                max_output_tokens=max_output_tokens,
+            )
+        )
+        status = response.status_code
+        response_text = response.text
+        if status != 200:
+            logger.warning("LLM call failed", status_code=status)
+            continue
+
+        status, _, json_content = interface.parse_response(response_text)
+        if status != 200:
+            logger.warning("Response parsing failed", status_code=status)
+            continue
+
+        status, res_molecules, res_explanations, res_confidence = validate_split_json(
+            json_content
+        )
+        if status != 200:
+            logger.warning("JSON validation failed", status_code=status)
+            continue
+
+        output_pathways, output_explanations, output_confidence = validity_check(
+            molecule,
+            res_molecules,
+            res_explanations,
+            res_confidence,
+        )
+
+        if run_stability and output_pathways:
+            previous_pathways = output_pathways
+            output_pathways = filter_stable_pathways(previous_pathways)
+            output_pathways, output_explanations, output_confidence = (
+                filter_metadata_by_pathways(
+                    output_pathways,
+                    previous_pathways,
+                    output_explanations,
+                    output_confidence,
+                )
+            )
+
+        if run_hallucination and output_pathways:
+            previous_pathways = output_pathways
+            output_pathways = filter_hallucination_pathways(molecule, previous_pathways)
+            output_pathways, output_explanations, output_confidence = (
+                filter_metadata_by_pathways(
+                    output_pathways,
+                    previous_pathways,
+                    output_explanations,
+                    output_confidence,
+                )
+            )
+
+        if output_pathways:
+            logger.info(
+                "Pipeline succeeded",
+                pathways=len(output_pathways),
+                explanations=len(output_explanations),
+            )
+            return output_pathways, output_explanations, output_confidence
+
+    return [], [], []

--- a/docs/source/package/deepretro.utils.llm.rst
+++ b/docs/source/package/deepretro.utils.llm.rst
@@ -1,0 +1,164 @@
+deepretro.utils.llm
+===================
+
+LiteLLM-backed single-step retrosynthesis utilities.
+
+The LLM code is split into three layers:
+
+- ``deepretro.utils.llm`` is the public workflow facade. It exposes prompt
+  selection, model calls, response parsing, JSON validation, pathway filtering,
+  and the ``llm_pipeline()`` orchestration function.
+- ``deepretro.utils.llm_interface`` owns provider-specific behavior. The
+  ``LLMInterface`` base class defines prompt construction, completion parameter
+  construction, API calling, and response parsing. Concrete implementations
+  handle Claude-style, OpenAI-style, DeepSeek-style, and generic responses.
+- ``deepretro.utils.llm_helpers`` contains model normalization and small parsing
+  helpers shared by the interface layer.
+
+Provider Interfaces
+-------------------
+
+Use ``create_llm_interface()`` when code needs direct access to the
+provider-specific interface:
+
+.. code-block:: python
+
+   from deepretro.utils.llm_interface import LLMRequest, create_llm_interface
+
+   interface = create_llm_interface("openai/gpt-4o-mini")
+   request = LLMRequest(
+       molecule="CCO",
+       model="openai/gpt-4o-mini",
+       max_output_tokens=2048,
+       enable_thinking=False,
+   )
+
+   messages = interface.build_messages(request)
+   params = interface.build_completion_params(request, messages)
+
+The factory returns one of these implementations:
+
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Interface
+     - Provider family
+     - Parser behavior
+   * - ``AnthropicLLM``
+     - Anthropic / Claude
+     - Requires ``<cot>`` content with at least one ``<thinking>`` entry and a
+       JSON payload. JSON is accepted in ``<json>`` tags or as fenced/raw JSON
+       after ``</cot>`` because Claude can return either shape.
+   * - ``OpenAILLM``
+     - OpenAI
+     - Extracts tagged, fenced, or raw JSON and does not return thinking steps.
+   * - ``DeepSeekLLM``
+     - DeepSeek
+     - Extracts optional ``<think>`` content plus tagged, fenced, or raw JSON.
+   * - ``GenericLLM``
+     - Fallback
+     - Uses the Claude-style parser for compatible providers.
+
+Public Workflow
+---------------
+
+Most callers should use the facade functions in ``deepretro.utils.llm``:
+
+.. code-block:: python
+
+   from deepretro.utils.llm import call_LLM, parse_response, validate_split_json
+
+   status, response_text = call_LLM(
+       molecule="CCO",
+       model="openai/gpt-4o-mini",
+       max_output_tokens=2048,
+       enable_thinking=False,
+   )
+
+   if status == 200:
+       parse_status, thinking_steps, json_content = parse_response(
+           response_text,
+           "openai/gpt-4o-mini",
+       )
+       if parse_status == 200:
+           validate_split_json(json_content)
+
+``llm_pipeline()`` combines the same steps into the end-to-end flow:
+
+.. code-block:: python
+
+   from deepretro.utils.llm import llm_pipeline
+
+   pathways, explanations, confidence = llm_pipeline(
+       molecule="CCO",
+       model="openai/gpt-4o-mini",
+       stability_check=False,
+       hallucination_check=False,
+       max_output_tokens=2048,
+       enable_thinking=False,
+   )
+
+Model Selection
+---------------
+
+Model identifiers are normalized before calling LiteLLM:
+
+- OpenAI models can be passed with a LiteLLM prefix, for example
+  ``openai/gpt-4o-mini``, or as names recognized by
+  ``deepretro.utils.variables.OPENAI_MODELS``.
+- OpenAI chat models use ``max_completion_tokens`` and receive a deterministic
+  ``seed``.
+- OpenAI reasoning models, such as ``gpt-5`` and ``o``-series models, use
+  ``reasoning_effort`` when reasoning controls are enabled. Their output-token
+  budget is raised to a provider-safe minimum.
+- Anthropic Claude 4 Opus/Sonnet models also receive ``reasoning_effort`` when
+  reasoning controls are enabled. Their output-token budget is raised to the
+  same provider-safe minimum, and their temperature is set to ``1`` for
+  reasoning calls.
+- DeepSeek aliases such as ``fireworks/deepseek-v3p2`` are normalized to the
+  preferred Fireworks-hosted DeepSeek R1 model.
+- A ``:adv`` suffix, such as ``openai/gpt-4o-mini:adv``, selects the advanced
+  prompt mode unless an explicit ``prompt_mode`` argument is provided.
+
+Testing
+-------
+
+Most tests in this module do not require live LLM credentials. They exercise
+provider selection, completion-parameter construction, parser behavior, JSON
+validation, and pipeline orchestration using local test doubles.
+
+The focused test file also includes two slow Anthropic integration tests. When
+``ANTHROPIC_API_KEY`` is configured, they call the live server with the real
+retrosynthesis prompt for aspirin in both standard and advanced prompt modes.
+Those tests assert that the response contains ``<cot>`` / ``<thinking>`` tags,
+that JSON can be extracted from either tagged or fenced output, and that
+``validate_split_json()`` can convert the payload into aligned pathways,
+explanations, and confidence scores.
+
+Run the focused test file with:
+
+.. code-block:: bash
+
+   uv run --project deepretro pytest deepretro/tests/test_llm.py -q
+
+Run only the live Anthropic prompt checks with:
+
+.. code-block:: bash
+
+   ANTHROPIC_API_KEY=... uv run --project deepretro pytest \
+       deepretro/tests/test_llm.py::test_live_anthropic_retrosynthesis_prompt_returns_parseable_tagged_json -q
+
+API
+---
+
+.. automodule:: deepretro.utils.llm
+   :members:
+
+.. automodule:: deepretro.utils.llm_interface
+   :members:
+   :no-index:
+
+.. automodule:: deepretro.utils.llm_helpers
+   :members:
+   :no-index:

--- a/docs/source/package/deepretro.utils_pkg.rst
+++ b/docs/source/package/deepretro.utils_pkg.rst
@@ -26,6 +26,8 @@ Utility Overview
      - Shortcut heuristic for trivial molecules to bypass heavy search.
    * - ``CacheManager`` / ``make_cache_key``
      - Explicit in-memory cache primitives for expensive library operations.
+   * - ``call_LLM`` / ``llm_pipeline``
+     - LiteLLM-backed retrosynthesis calls, response parsing, and pathway filtering.
 
 
 AiZynthFinder Integration Notes
@@ -65,6 +67,7 @@ Submodules
    deepretro.utils.az
    deepretro.utils.metrics
    deepretro.utils.cache
+   deepretro.utils.llm
    deepretro.utils.utils_molecule
 
 API Reference


### PR DESCRIPTION
## Summary

- Add the public `deepretro.utils.llm` facade for LLM calls, response parsing, JSON validation, and pathway filtering.
- Add `llm_pipeline()` orchestration with DeepSeek fallback behavior and compatibility wrappers for existing parser names.
- Add LLM utility documentation and package docs navigation.

## Stack

Depends on #202.