### PR TITLE
Port AutoSolver onto deepretro package API

### DIFF
--- a/deepretro/__init__.py
+++ b/deepretro/__init__.py
@@ -5,7 +5,12 @@ Provides DeepChem-compatible featurizers, dataset loaders, algorithms,
 and model wrappers for reaction-step data.
 """
 
-__all__ = ["ReactionStepFeaturizer", "configure_logging", "HallucinationClassifier"]
+__all__ = [
+    "AutoSolver",
+    "HallucinationClassifier",
+    "ReactionStepFeaturizer",
+    "configure_logging",
+]
 
 
 def __getattr__(name: str):
@@ -21,4 +26,8 @@ def __getattr__(name: str):
         from deepretro.models.hallucination_classifier import HallucinationClassifier
 
         return HallucinationClassifier
+    if name == "AutoSolver":
+        from deepretro.algorithms.autosolve import AutoSolver
+
+        return AutoSolver
     raise AttributeError(f"module 'deepretro' has no attribute {name!r}")

--- a/deepretro/algorithms/__init__.py
+++ b/deepretro/algorithms/__init__.py
@@ -13,6 +13,7 @@ from .stability_checker import (
 )
 
 __all__ = [
+    "AutoSolver",
     "calculate_hallucination_score",
     "hallucination_compare_molecules",
     "interpret_score",
@@ -22,3 +23,11 @@ __all__ = [
     "check_carbenes",
     "check_fused_cyclopentane",
 ]
+
+
+def __getattr__(name: str):
+    if name == "AutoSolver":
+        from deepretro.algorithms.autosolve import AutoSolver
+
+        return AutoSolver
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/deepretro/algorithms/autosolve.py
+++ b/deepretro/algorithms/autosolve.py
@@ -1,0 +1,269 @@
+"""Automatic single-molecule retrosynthesis solver."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Optional
+
+import structlog
+from rdkit import Chem
+
+from deepretro.models.hallucination_helpers import (
+    HallucinationChecker,
+    filter_with_checker,
+    resolve_hallucination,
+)
+from deepretro.utils.az import run_az
+from deepretro.utils.llm_helpers import Pathway
+from deepretro.utils.parse import format_output
+from deepretro.utils.typing import ParseOutput, RouteNode
+
+logger = structlog.get_logger(__name__)
+
+
+class AutoSolver:
+    """Solve a target molecule with AiZynthFinder and an LLM fallback.
+
+    Parameters
+    ----------
+    llm : str, optional
+        LiteLLM model identifier used by the fallback retrosynthesis pipeline.
+    az_model : str, optional
+        AiZynthFinder model variant.
+    stability_check : bool, optional
+        Whether LLM candidates should pass the heuristic stability filter.
+    hallucination_mode : {"heuristic", "ml", "none"}, optional
+        Hallucination filter strategy. The heuristic mode delegates to the
+        package LLM pipeline; ML mode applies the provided classifier after
+        the LLM pipeline returns candidates.
+    hallucination_classifier : str, Path, object, or None, optional
+        Saved classifier directory or classifier object for ML hallucination
+        filtering.
+    max_depth : int, optional
+        Maximum retrosynthesis recursion depth.
+    enable_thinking : bool, optional
+        Whether provider-supported reasoning controls should be enabled.
+    max_output_tokens : int, optional
+        Output-token override for LLM calls.
+    """
+
+    def __init__(
+        self,
+        llm: str = "anthropic/claude-opus-4-6:adv",
+        az_model: str = "Pistachio_100+",
+        stability_check: bool = True,
+        hallucination_mode: str = "heuristic",
+        hallucination_classifier: str | Path | Any | None = None,
+        max_depth: int = 50,
+        enable_thinking: bool = True,
+        max_output_tokens: int | None = None,
+    ) -> None:
+        self.llm = llm
+        self.az_model = az_model
+        self.stability_check = stability_check
+        self.hallucination_mode = hallucination_mode.lower()
+        self.hallucination_checker: Optional[HallucinationChecker] = (
+            resolve_hallucination(
+                self.hallucination_mode,
+                hallucination_classifier,
+            )
+        )
+        self.max_depth = max_depth
+        self.enable_thinking = enable_thinking
+        self.max_output_tokens = max_output_tokens
+
+    def solve(self, smiles: str, *, return_image: bool = False) -> ParseOutput:
+        """Run retrosynthesis and return viewer-ready pathway data.
+
+        Parameters
+        ----------
+        smiles : str
+            Target molecule SMILES.
+        return_image : bool, optional
+            If ``True``, append an ``"image"`` key containing a rendered PIL
+            image of the formatted pathway.
+
+        Returns
+        -------
+        dict[str, Any]
+            Output from :func:`deepretro.utils.parse.format_output`.
+        """
+        log = logger.bind(job_id=f"{time.strftime('%Y%m%d_%H%M%S')}_{os.getpid()}")
+        route_tree, solved = self.recurse(smiles)
+        output = format_output(route_tree)
+        output["solved"] = solved
+        log.info("AutoSolver completed", molecule=smiles, solved=solved)
+
+        if return_image:
+            from deepretro.utils.visualize import visualize_pathway
+
+            output["image"] = visualize_pathway(output)
+        return output
+
+    def recurse(
+        self,
+        molecule: str,
+        visited: set[str] | None = None,
+        depth: int = 0,
+    ) -> tuple[dict[str, Any], bool]:
+        """Recursively solve one molecule.
+
+        Parameters
+        ----------
+        molecule : str
+            Molecule SMILES to solve.
+        visited : set[str], optional
+            Canonical SMILES already visited on the current branch.
+        depth : int, optional
+            Current recursion depth.
+
+        Returns
+        -------
+        tuple[dict[str, Any], bool]
+            Route tree and solved flag.
+        """
+        canonical = canonicalize(molecule)
+        if depth >= self.max_depth:
+            logger.warning("Maximum recursion depth reached", molecule=molecule)
+            return unsolved_leaf(molecule), False
+
+        branch_visited = set() if visited is None else set(visited)
+        if canonical in branch_visited:
+            logger.warning("Cycle detected in retrosynthesis tree", molecule=molecule)
+            return unsolved_leaf(molecule), False
+        branch_visited.add(canonical)
+
+        az_solved, az_routes = run_az(smiles=molecule, az_model=self.az_model)
+        if az_solved and az_routes:
+            logger.info("AiZynthFinder solved molecule", molecule=molecule)
+            return dict(az_routes[0]), True
+
+        pathways, explanations, confidence = self._run_llm_fallback(molecule)
+        if not pathways:
+            logger.info("LLM fallback returned no usable pathways", molecule=molecule)
+            return unsolved_leaf(molecule), False
+
+        first_attempted_children: list[dict[str, Any]] | None = None
+        for pathway in pathways:
+            candidate_children, candidate_solved = self._solve_pathway(
+                pathway,
+                branch_visited,
+                depth,
+            )
+            if first_attempted_children is None:
+                first_attempted_children = candidate_children
+            if candidate_solved:
+                return reaction_tree(molecule, candidate_children, confidence), True
+
+        return reaction_tree(
+            molecule,
+            [] if first_attempted_children is None else first_attempted_children,
+            confidence,
+        ), False
+
+    def _run_llm_fallback(
+        self,
+        molecule: str,
+    ) -> tuple[list[Pathway], list[str], list[float]]:
+        """Call the package LLM pipeline and apply optional ML filtering."""
+        pathways, explanations, confidence = llm_pipeline(
+            molecule=molecule,
+            model=self.llm,
+            stability_check=self.stability_check,
+            hallucination_check=self.hallucination_mode == "heuristic",
+            enable_thinking=self.enable_thinking,
+            max_output_tokens=self.max_output_tokens,
+        )
+        return filter_with_checker(
+            molecule,
+            pathways,
+            explanations,
+            confidence,
+            self.hallucination_checker,
+        )
+
+    def _solve_pathway(
+        self,
+        pathway: Sequence[str] | str,
+        visited: set[str],
+        depth: int,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Solve each reactant in a candidate precursor pathway."""
+        reactants = [pathway] if isinstance(pathway, str) else list(pathway)
+        children: list[dict[str, Any]] = []
+        all_solved = True
+        for reactant in reactants:
+            child, solved = self.recurse(reactant, visited, depth + 1)
+            children.append(child)
+            all_solved = all_solved and solved
+        return children, all_solved
+
+
+def canonicalize(smiles: str) -> str:
+    """Return canonical SMILES, or the original string if parsing fails.
+
+    Examples
+    --------
+    >>> canonicalize("C(O)C")
+    'CCO'
+    >>> canonicalize("not_a_smiles")
+    'not_a_smiles'
+    """
+    molecule = Chem.MolFromSmiles(smiles)
+    if molecule is None:
+        return smiles
+    return Chem.MolToSmiles(molecule, canonical=True)
+
+
+def llm_pipeline(**kwargs: Any) -> tuple[list[Pathway], list[str], list[float]]:
+    """Import and call the LLM pipeline lazily.
+
+    Keeping this import lazy lets users import ``deepretro.AutoSolver`` in
+    lightweight environments that have not installed LLM provider extras yet.
+    """
+    from deepretro.utils.llm import llm_pipeline as package_llm_pipeline
+
+    return package_llm_pipeline(**kwargs)
+
+
+def unsolved_leaf(smiles: str) -> dict[str, Any]:
+    """Build a terminal route node for an unresolved molecule.
+
+    Examples
+    --------
+    >>> unsolved_leaf("CCO")["in_stock"]
+    False
+    """
+    return {
+        "type": "mol",
+        "smiles": smiles,
+        "is_chemical": True,
+        "in_stock": False,
+        "children": [],
+    }
+
+
+def reaction_tree(
+    molecule: str,
+    children: Sequence[RouteNode],
+    confidence: Sequence[float],
+) -> dict[str, Any]:
+    """Build the route-tree shape consumed by ``RetrosynthesisRouteParser``."""
+    policy_probability = float(confidence[0]) if confidence else 0.0
+    return {
+        "type": "mol",
+        "smiles": molecule,
+        "is_chemical": True,
+        "in_stock": False,
+        "children": [
+            {
+                "type": "reaction",
+                "is_reaction": True,
+                "metadata": {"policy_probability": policy_probability},
+                "children": list(children),
+            }
+        ],
+    }

--- a/deepretro/models/__init__.py
+++ b/deepretro/models/__init__.py
@@ -1,8 +1,22 @@
 """Model wrappers for retrosynthesis ML tasks."""
 
-from deepretro.models.hallucination_classifier import (
-    HallucinationClassifier,
-    predict_single_reaction,
-)
+from __future__ import annotations
 
-__all__ = ["HallucinationClassifier", "predict_single_reaction"]
+__all__ = [
+    "HallucinationClassifier",
+    "build_ml_checker",
+    "predict_single_reaction",
+    "resolve_hallucination",
+]
+
+
+def __getattr__(name: str):
+    if name in {"HallucinationClassifier", "predict_single_reaction"}:
+        from deepretro.models import hallucination_classifier
+
+        return getattr(hallucination_classifier, name)
+    if name in {"build_ml_checker", "resolve_hallucination"}:
+        from deepretro.models import hallucination_helpers
+
+        return getattr(hallucination_helpers, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/deepretro/models/hallucination_helpers.py
+++ b/deepretro/models/hallucination_helpers.py
@@ -1,0 +1,140 @@
+"""Helpers for optional hallucination filtering in retrosynthesis pipelines."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
+
+from deepretro.utils.llm_helpers import Pathway
+
+HallucinationChecker = Callable[[str, list[Pathway]], tuple[int, list[Pathway]]]
+
+
+def _as_pathway(candidate: Pathway | str) -> Pathway:
+    """Normalize one candidate into a pathway list."""
+    return [candidate] if isinstance(candidate, str) else list(candidate)
+
+
+def build_ml_checker(classifier: Any) -> HallucinationChecker:
+    """Wrap a classifier in the checker interface used by ``AutoSolver``.
+
+    Parameters
+    ----------
+    classifier : Any
+        Object exposing ``predict_single(product_smiles, reactants_smiles)``.
+
+    Returns
+    -------
+    HallucinationChecker
+        Callable returning ``(200, retained_pathways)``.
+    """
+
+    def _checker(product: str, pathways: list[Pathway]) -> tuple[int, list[Pathway]]:
+        from deepretro.utils.utils_molecule import is_valid_smiles
+
+        retained: list[Pathway] = []
+        for candidate in pathways:
+            pathway = _as_pathway(candidate)
+            reactants_smiles = ".".join(pathway)
+            if not is_valid_smiles(reactants_smiles):
+                continue
+
+            prediction = classifier.predict_single(product, reactants_smiles)
+            if not bool(prediction.get("is_hallucination", True)):
+                retained.append(pathway)
+
+        return 200, retained
+
+    return _checker
+
+
+def filter_with_checker(
+    product: str,
+    pathways: list[Pathway],
+    explanations: Iterable[str],
+    confidence: Iterable[float],
+    checker: HallucinationChecker | None,
+) -> tuple[list[Pathway], list[str], list[float]]:
+    """Filter pathways and keep explanations/confidence aligned.
+
+    Parameters
+    ----------
+    product : str
+        Product molecule SMILES.
+    pathways : list[list[str]]
+        Candidate precursor pathways.
+    explanations : Iterable[str]
+        Explanations aligned with ``pathways``.
+    confidence : Iterable[float]
+        Confidence scores aligned with ``pathways``.
+    checker : HallucinationChecker or None
+        Optional pathway filter.
+
+    Returns
+    -------
+    tuple[list[list[str]], list[str], list[float]]
+        Retained pathways with aligned metadata.
+    """
+    if checker is None or not pathways:
+        return pathways, list(explanations), list(confidence)
+
+    status, retained_pathways = checker(product, pathways)
+    if status != 200:
+        return [], [], []
+
+    retained_explanations: list[str] = []
+    retained_confidence: list[float] = []
+    available = list(zip(pathways, explanations, confidence))
+    for retained in retained_pathways:
+        for index, (pathway, explanation, score) in enumerate(available):
+            if pathway == retained:
+                retained_explanations.append(explanation)
+                retained_confidence.append(float(score))
+                available.pop(index)
+                break
+
+    return retained_pathways, retained_explanations, retained_confidence
+
+
+def resolve_hallucination(
+    mode: str,
+    classifier: str | Path | Any | None,
+) -> HallucinationChecker | None:
+    """Resolve an AutoSolver hallucination mode into a checker callable.
+
+    Parameters
+    ----------
+    mode : str
+        One of ``"heuristic"``, ``"ml"``, or ``"none"``.
+    classifier : str, Path, object, or None
+        Saved classifier directory or classifier object for ``"ml"`` mode.
+
+    Returns
+    -------
+    HallucinationChecker or None
+        ``None`` for ``"none"`` and ``"heuristic"`` because the built-in
+        heuristic path is handled by ``deepretro.utils.llm.llm_pipeline``.
+    """
+    normalized_mode = mode.lower()
+    if normalized_mode in {"none", "heuristic"}:
+        return None
+    if normalized_mode != "ml":
+        raise ValueError(
+            f"hallucination_mode must be 'heuristic', 'ml', or 'none' (got {mode!r})"
+        )
+
+    if isinstance(classifier, (str, Path)):
+        from deepretro.models.hallucination_classifier import HallucinationClassifier
+
+        loaded_classifier = HallucinationClassifier()
+        loaded_classifier.load(str(classifier))
+        return build_ml_checker(loaded_classifier)
+
+    if hasattr(classifier, "predict_single"):
+        return build_ml_checker(classifier)
+
+    raise ValueError(
+        "hallucination_mode='ml' requires a HallucinationClassifier instance "
+        "or path to a saved classifier"
+    )

--- a/deepretro/tests/test_autosolve.py
+++ b/deepretro/tests/test_autosolve.py
@@ -1,0 +1,308 @@
+"""Tests for the package AutoSolver orchestration layer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import deepretro.algorithms.autosolve as autosolve
+from deepretro.algorithms.autosolve import (
+    AutoSolver,
+    canonicalize,
+    reaction_tree,
+    unsolved_leaf,
+)
+
+TARGET = "CCCO"
+ETHANOL = "CCO"
+METHANOL = "CO"
+
+
+def solved_route(smiles: str) -> dict[str, Any]:
+    """Return a minimal solved route node for tests."""
+    return {
+        "type": "mol",
+        "smiles": smiles,
+        "is_chemical": True,
+        "in_stock": True,
+    }
+
+
+def test_public_lazy_exports_import_autosolver() -> None:
+    """Package-level and algorithms-level lazy exports expose AutoSolver."""
+    import deepretro
+    import deepretro.algorithms
+
+    assert deepretro.AutoSolver is AutoSolver
+    assert deepretro.algorithms.AutoSolver is AutoSolver
+
+
+def test_solve_formats_recurse_tree_and_adds_solved_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """solve() delegates to recurse() and formats the returned route tree."""
+    fake_tree = reaction_tree(TARGET, [solved_route(ETHANOL)], [0.8])
+    fake_output = {"steps": [{"step": "1"}], "dependencies": {"1": []}}
+    calls: dict[str, Any] = {}
+
+    def fake_recurse(self: AutoSolver, smiles: str) -> tuple[dict[str, Any], bool]:
+        calls["recurse"] = smiles
+        return fake_tree, True
+
+    def fake_format(tree: dict[str, Any]) -> dict[str, Any]:
+        calls["format"] = tree
+        return dict(fake_output)
+
+    monkeypatch.setattr(AutoSolver, "recurse", fake_recurse)
+    monkeypatch.setattr(autosolve, "format_output", fake_format)
+
+    result = AutoSolver(hallucination_mode="none").solve(TARGET)
+
+    assert result == {**fake_output, "solved": True}
+    assert calls == {"recurse": TARGET, "format": fake_tree}
+
+
+def test_solve_can_append_rendered_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    """return_image=True calls visualization with the formatted output."""
+    fake_tree = reaction_tree(TARGET, [solved_route(ETHANOL)], [0.8])
+    image = object()
+    visualized: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        AutoSolver,
+        "recurse",
+        lambda self, smiles: (fake_tree, True),
+    )
+    monkeypatch.setattr(
+        autosolve,
+        "format_output",
+        lambda tree: {"steps": [], "dependencies": {}},
+    )
+
+    import deepretro.utils.visualize as visualize
+
+    def fake_visualize(output: dict[str, Any]) -> object:
+        visualized["output"] = dict(output)
+        return image
+
+    monkeypatch.setattr(visualize, "visualize_pathway", fake_visualize)
+
+    result = AutoSolver(hallucination_mode="none").solve(TARGET, return_image=True)
+
+    assert result["image"] is image
+    assert visualized["output"] == {"steps": [], "dependencies": {}, "solved": True}
+
+
+def test_constructor_preserves_public_options() -> None:
+    """Constructor options are stored without invoking external services."""
+    solver = AutoSolver(
+        llm="openai/gpt-4o-mini:adv",
+        az_model="USPTO",
+        stability_check=False,
+        hallucination_mode="none",
+        max_depth=3,
+        enable_thinking=False,
+        max_output_tokens=128,
+    )
+
+    assert solver.llm == "openai/gpt-4o-mini:adv"
+    assert solver.az_model == "USPTO"
+    assert solver.stability_check is False
+    assert solver.hallucination_mode == "none"
+    assert solver.hallucination_checker is None
+    assert solver.max_depth == 3
+    assert solver.enable_thinking is False
+    assert solver.max_output_tokens == 128
+
+
+def test_recurse_returns_first_az_route_without_calling_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AiZynthFinder success short-circuits LLM fallback."""
+    llm_calls: list[str] = []
+    first_route = solved_route(TARGET)
+    second_route = solved_route("CCCC")
+
+    monkeypatch.setattr(
+        autosolve,
+        "run_az",
+        lambda smiles, az_model: (True, [first_route, second_route]),
+    )
+    monkeypatch.setattr(
+        autosolve,
+        "llm_pipeline",
+        lambda **kwargs: llm_calls.append(kwargs["molecule"]),
+    )
+
+    route, solved = AutoSolver(hallucination_mode="none").recurse(TARGET)
+
+    assert solved is True
+    assert route == first_route
+    assert llm_calls == []
+
+
+def test_recurse_calls_llm_with_package_pipeline_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLM fallback uses the target branch ``deepretro.utils.llm`` contract."""
+    captured: dict[str, Any] = {}
+
+    def fake_run_az(smiles: str, az_model: str) -> tuple[bool, list[dict[str, Any]]]:
+        return (True, [solved_route(smiles)]) if smiles == METHANOL else (False, [])
+
+    def fake_llm_pipeline(
+        **kwargs: Any,
+    ) -> tuple[list[list[str]], list[str], list[float]]:
+        captured.update(kwargs)
+        return [[METHANOL]], ["reduce chain"], [0.7]
+
+    monkeypatch.setattr(autosolve, "run_az", fake_run_az)
+    monkeypatch.setattr(autosolve, "llm_pipeline", fake_llm_pipeline)
+
+    route, solved = AutoSolver(
+        llm="openai/gpt-4o-mini",
+        az_model="USPTO",
+        stability_check=False,
+        hallucination_mode="heuristic",
+        enable_thinking=False,
+        max_output_tokens=64,
+    ).recurse(TARGET)
+
+    assert solved is True
+    assert route["children"][0]["children"] == [solved_route(METHANOL)]
+    assert captured["molecule"] == TARGET
+    assert captured["model"] == "openai/gpt-4o-mini"
+    assert captured["stability_check"] is False
+    assert captured["hallucination_check"] is True
+    assert captured["enable_thinking"] is False
+    assert captured["max_output_tokens"] == 64
+
+
+def test_recurse_selects_first_fully_solved_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed candidate does not pollute the selected successful route."""
+
+    def fake_run_az(smiles: str, az_model: str) -> tuple[bool, list[dict[str, Any]]]:
+        return (True, [solved_route(smiles)]) if smiles == METHANOL else (False, [])
+
+    def fake_llm_pipeline(
+        **kwargs: Any,
+    ) -> tuple[list[list[str]], list[str], list[float]]:
+        if kwargs["molecule"] == TARGET:
+            return [[ETHANOL], [METHANOL]], ["bad", "good"], [0.2, 0.9]
+        return [], [], []
+
+    monkeypatch.setattr(autosolve, "run_az", fake_run_az)
+    monkeypatch.setattr(autosolve, "llm_pipeline", fake_llm_pipeline)
+
+    route, solved = AutoSolver(hallucination_mode="none").recurse(TARGET)
+
+    assert solved is True
+    assert route["children"][0]["children"] == [solved_route(METHANOL)]
+    assert unsolved_leaf(ETHANOL) not in route["children"][0]["children"]
+
+
+def test_recurse_returns_first_partial_candidate_when_none_fully_solve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If all candidates fail, the first attempted route remains inspectable."""
+
+    def fake_llm_pipeline(
+        **kwargs: Any,
+    ) -> tuple[list[list[str]], list[str], list[float]]:
+        if kwargs["molecule"] != TARGET:
+            return [], [], []
+        return [[ETHANOL], [METHANOL]], ["first", "second"], [0.2, 0.9]
+
+    monkeypatch.setattr(autosolve, "run_az", lambda smiles, az_model: (False, []))
+    monkeypatch.setattr(autosolve, "llm_pipeline", fake_llm_pipeline)
+
+    route, solved = AutoSolver(hallucination_mode="none").recurse(TARGET)
+
+    assert solved is False
+    assert route["children"][0]["children"] == [unsolved_leaf(ETHANOL)]
+
+
+def test_recurse_solves_multi_reactant_pathway(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every reactant in a candidate pathway must solve for the route to solve."""
+
+    def fake_run_az(smiles: str, az_model: str) -> tuple[bool, list[dict[str, Any]]]:
+        return (
+            (True, [solved_route(smiles)])
+            if smiles in {ETHANOL, METHANOL}
+            else (False, [])
+        )
+
+    monkeypatch.setattr(autosolve, "run_az", fake_run_az)
+    monkeypatch.setattr(
+        autosolve,
+        "llm_pipeline",
+        lambda **kwargs: ([[ETHANOL, METHANOL]], ["two reactants"], [0.8]),
+    )
+
+    route, solved = AutoSolver(hallucination_mode="none").recurse(TARGET)
+
+    assert solved is True
+    assert route["children"][0]["children"] == [
+        solved_route(ETHANOL),
+        solved_route(METHANOL),
+    ]
+
+
+def test_recurse_returns_unsolved_tree_when_llm_has_no_pathways(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No LLM candidates yields a stable unsolved leaf."""
+    monkeypatch.setattr(autosolve, "run_az", lambda smiles, az_model: (False, []))
+    monkeypatch.setattr(autosolve, "llm_pipeline", lambda **kwargs: ([], [], []))
+
+    route, solved = AutoSolver(hallucination_mode="none").recurse(TARGET)
+
+    assert solved is False
+    assert route == unsolved_leaf(TARGET)
+
+
+def test_recurse_detects_canonical_cycles(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Canonicalized revisits stop recursion."""
+    monkeypatch.setattr(autosolve, "run_az", lambda smiles, az_model: (False, []))
+    monkeypatch.setattr(
+        autosolve,
+        "llm_pipeline",
+        lambda **kwargs: ([["C(O)C"]], ["same molecule"], [0.1]),
+    )
+
+    route, solved = AutoSolver(hallucination_mode="none").recurse("CCO")
+
+    assert solved is False
+    assert route["children"][0]["children"] == [unsolved_leaf("C(O)C")]
+
+
+def test_recurse_stops_at_max_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The recursion limit returns an unsolved leaf before external calls."""
+    run_az_calls: list[str] = []
+
+    def fake_run_az(smiles: str, az_model: str) -> tuple[bool, list[dict[str, Any]]]:
+        run_az_calls.append(smiles)
+        return False, []
+
+    monkeypatch.setattr(autosolve, "run_az", fake_run_az)
+
+    route, solved = AutoSolver(hallucination_mode="none", max_depth=0).recurse(TARGET)
+
+    assert (route, solved) == (unsolved_leaf(TARGET), False)
+    assert run_az_calls == []
+
+
+def test_canonicalize_and_unsolved_leaf_helpers() -> None:
+    """Small helpers expose stable deterministic behavior."""
+    assert canonicalize("C(O)C") == "CCO"
+    assert canonicalize("not_a_smiles") == "not_a_smiles"
+    assert unsolved_leaf("CCO") == {
+        "type": "mol",
+        "smiles": "CCO",
+        "is_chemical": True,
+        "in_stock": False,
+        "children": [],
+    }

--- a/deepretro/tests/test_hallucination_helpers.py
+++ b/deepretro/tests/test_hallucination_helpers.py
@@ -1,0 +1,140 @@
+"""Tests for hallucination checker adapter helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import call
+
+import pytest
+
+from deepretro.models.hallucination_helpers import (
+    build_ml_checker,
+    filter_with_checker,
+    resolve_hallucination,
+)
+
+
+def test_build_ml_checker_keeps_non_hallucinated_pathways(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ML checker keeps pathways whose classifier prediction is clean."""
+    classifier = MagicMock()
+    classifier.predict_single.side_effect = [
+        {"is_hallucination": True},
+        {"is_hallucination": False},
+    ]
+    monkeypatch.setattr(
+        "deepretro.utils.utils_molecule.is_valid_smiles",
+        lambda smiles: True,
+    )
+
+    status, retained = build_ml_checker(classifier)("CCO", [["CC"], ["CO"]])
+
+    assert status == 200
+    assert retained == [["CO"]]
+    classifier.predict_single.assert_has_calls(
+        [
+            call("CCO", "CC"),
+            call("CCO", "CO"),
+        ]
+    )
+
+
+def test_build_ml_checker_drops_invalid_reactant_sets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid joined reactant SMILES are ignored before classifier calls."""
+    classifier = MagicMock()
+    monkeypatch.setattr(
+        "deepretro.utils.utils_molecule.is_valid_smiles",
+        lambda smiles: False,
+    )
+
+    status, retained = build_ml_checker(classifier)("CCO", [["not-valid"]])
+
+    assert status == 200
+    assert retained == []
+    classifier.predict_single.assert_not_called()
+
+
+def test_filter_with_checker_preserves_explanation_and_confidence_alignment() -> None:
+    """Filtering retains metadata aligned to the surviving pathway."""
+
+    def checker(product: str, pathways: list[list[str]]) -> tuple[int, list[list[str]]]:
+        assert product == "CCO"
+        assert pathways == [["CC"], ["CO"]]
+        return 200, [["CO"]]
+
+    pathways, explanations, confidence = filter_with_checker(
+        "CCO",
+        [["CC"], ["CO"]],
+        ["first", "second"],
+        [0.1, 0.9],
+        checker,
+    )
+
+    assert pathways == [["CO"]]
+    assert explanations == ["second"]
+    assert confidence == [0.9]
+
+
+def test_filter_with_checker_short_circuits_without_checker() -> None:
+    """No checker leaves pathways and metadata unchanged."""
+    pathways, explanations, confidence = filter_with_checker(
+        "CCO",
+        [["CC"], ["CO"]],
+        ["first", "second"],
+        [0.1, 0.9],
+        None,
+    )
+
+    assert pathways == [["CC"], ["CO"]]
+    assert explanations == ["first", "second"]
+    assert confidence == [0.1, 0.9]
+
+
+def test_filter_with_checker_returns_empty_on_checker_failure() -> None:
+    """Non-200 checker status drops all aligned metadata."""
+
+    def checker(product: str, pathways: list[list[str]]) -> tuple[int, list[list[str]]]:
+        return 500, pathways
+
+    assert filter_with_checker("CCO", [["CC"]], ["first"], [0.1], checker) == (
+        [],
+        [],
+        [],
+    )
+
+
+def test_filter_with_checker_handles_duplicate_pathways_in_order() -> None:
+    """Duplicate retained pathways consume metadata entries one at a time."""
+
+    def checker(product: str, pathways: list[list[str]]) -> tuple[int, list[list[str]]]:
+        return 200, [["CC"], ["CC"]]
+
+    pathways, explanations, confidence = filter_with_checker(
+        "CCO",
+        [["CC"], ["CC"], ["CO"]],
+        ["first", "second", "third"],
+        [0.1, 0.2, 0.3],
+        checker,
+    )
+
+    assert pathways == [["CC"], ["CC"]]
+    assert explanations == ["first", "second"]
+    assert confidence == [0.1, 0.2]
+
+
+def test_resolve_hallucination_modes() -> None:
+    """Mode resolution is explicit and validates ML classifier inputs."""
+    assert resolve_hallucination("none", None) is None
+    assert resolve_hallucination("heuristic", None) is None
+
+    classifier = MagicMock()
+    classifier.predict_single.return_value = {"is_hallucination": False}
+    assert callable(resolve_hallucination("ml", classifier))
+
+    with pytest.raises(ValueError, match="hallucination_mode"):
+        resolve_hallucination("unknown", None)
+    with pytest.raises(ValueError, match="requires"):
+        resolve_hallucination("ml", None)

--- a/deepretro/utils/__init__.py
+++ b/deepretro/utils/__init__.py
@@ -20,4 +20,13 @@ __all__ = [
     "extract_domain_features_single",
     "NUM_DOMAIN_FEATURES",
     "find_optimal_threshold",
+    "visualize_pathway",
 ]
+
+
+def __getattr__(name: str):
+    if name == "visualize_pathway":
+        from deepretro.utils.visualize import visualize_pathway
+
+        return visualize_pathway
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/deepretro/utils/az.py
+++ b/deepretro/utils/az.py
@@ -6,16 +6,28 @@ Requires ``AZ_MODEL_CONFIG_PATH`` or ``AZ_MODELS_PATH`` environment variables.
 """
 
 import os
-from aizynthfinder.aizynthfinder import AiZynthFinder
+from pathlib import Path
 from typing import Any, Dict, Sequence
-from src.variables import BASIC_MOLECULES
-from src.cache import cache_results
-import rootutils
+
+from dotenv import load_dotenv
+from PIL.Image import Image
 from rdkit import Chem
 from rdkit.Chem import rdqueries
-from PIL.Image import Image
 
-root_dir = rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
+from deepretro.utils.variables import BASIC_MOLECULES
+
+load_dotenv()
+
+
+def _find_project_root(start: Path, marker: str = ".project-root") -> Path:
+    """Walk up from *start* until a directory containing *marker* is found."""
+    for directory in [start.resolve(), *start.resolve().parents]:
+        if (directory / marker).exists():
+            return directory
+    return Path.cwd()
+
+
+root_dir = _find_project_root(Path(__file__))
 
 ENABLE_LOGGING = (
     False if os.getenv("ENABLE_LOGGING", "true").lower() == "false" else True
@@ -46,7 +58,6 @@ def _log(message: str, logger=None):
         print(message)
 
 
-@cache_results
 def run_az(
     smiles: str, az_model: str = "USPTO"
 ) -> tuple[bool, Sequence[Dict[str, Any]]]:
@@ -96,6 +107,8 @@ def run_az(
                 "in_stock": True,
             }
         ]
+    from aizynthfinder.aizynthfinder import AiZynthFinder
+
     finder = AiZynthFinder(configfile=config_filename)
     finder.stock.select("zinc")
     finder.expansion_policy.select("uspto")
@@ -111,7 +124,6 @@ def run_az(
     return status, result_dict
 
 
-@cache_results
 def run_az_with_img(
     smiles: str,
 ) -> tuple[bool, Sequence[Dict[str, Any]], Sequence[Image | None] | None]:
@@ -150,6 +162,8 @@ def run_az_with_img(
             ],
             None,
         )
+    from aizynthfinder.aizynthfinder import AiZynthFinder
+
     finder = AiZynthFinder(configfile=AZ_MODEL_CONFIG_PATH)
     finder.stock.select("zinc")
     finder.expansion_policy.select("uspto")

--- a/deepretro/utils/visualize.py
+++ b/deepretro/utils/visualize.py
@@ -1,0 +1,283 @@
+"""Render formatted retrosynthesis pathways as static images."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import Any
+
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+from rdkit import Chem
+from rdkit.Chem import Descriptors, Draw, rdMolDescriptors
+from rdkit.Chem.Draw import rdMolDraw2D
+
+BACKGROUND = (255, 255, 255)
+LINE_COLOR = (180, 180, 180)
+TEXT_COLOR = (80, 80, 80)
+TARGET_FILL = (210, 235, 210)
+TARGET_STROKE = (130, 185, 130)
+STEP_FILL = (210, 225, 245)
+STEP_STROKE = (150, 180, 215)
+MAIN_RADIUS = 105
+SMALL_RADIUS = 68
+COLUMN_GAP = 310
+MOLECULE_CELL_HEIGHT = 200
+CHILD_GAP = 30
+PADDING = 80
+
+
+@dataclass
+class PathwayNode:
+    """Renderable pathway node."""
+
+    label: str
+    molecules: list[dict[str, Any]]
+    is_target: bool = False
+    children: list["PathwayNode"] = field(default_factory=list)
+    x: int = 0
+    y: int = 0
+
+
+def build_tree(result: dict[str, Any]) -> PathwayNode | None:
+    """Build a render tree from formatted AutoSolver output."""
+    steps = result.get("steps", [])
+    dependencies = result.get("dependencies", {})
+    if not steps:
+        return None
+
+    step_map = {step["step"]: step for step in steps}
+    first_step = step_map.get("1")
+    if first_step is None:
+        return None
+
+    target = first_step["products"][0] if first_step.get("products") else None
+    root = PathwayNode(
+        label="Step 0",
+        molecules=[target] if target else [],
+        is_target=True,
+    )
+
+    def _recurse(step_id: str) -> PathwayNode:
+        step = step_map[step_id]
+        node = PathwayNode(
+            label=f"Step {step_id}",
+            molecules=step.get("reactants", []),
+        )
+        for child_id in dependencies.get(step_id, []):
+            if child_id in step_map:
+                node.children.append(_recurse(child_id))
+        return node
+
+    root.children.append(_recurse("1"))
+    return root
+
+
+def node_height(node: PathwayNode) -> int:
+    """Return the pixel height needed for a node subtree."""
+    own_height = max(len(node.molecules), 1) * MOLECULE_CELL_HEIGHT
+    if not node.children:
+        return own_height
+    child_height = sum(node_height(child) for child in node.children)
+    child_height += CHILD_GAP * (len(node.children) - 1)
+    return max(own_height, child_height)
+
+
+def layout(node: PathwayNode, x: int, y_start: int, y_end: int) -> None:
+    """Assign coordinates to every node in a render tree."""
+    node.x = x
+    node.y = (y_start + y_end) // 2
+    if not node.children:
+        return
+
+    needed_height = sum(node_height(child) for child in node.children)
+    needed_height += CHILD_GAP * (len(node.children) - 1)
+    y = y_start + max(0, (y_end - y_start - needed_height) // 2)
+    for child in node.children:
+        child_height = node_height(child)
+        layout(child, x + COLUMN_GAP, y, y + child_height)
+        y += child_height + CHILD_GAP
+
+
+def render_molecule(smiles: str, size: int) -> Image.Image | None:
+    """Render one SMILES string to a transparent molecule image."""
+    molecule = Chem.MolFromSmiles(smiles)
+    if molecule is None:
+        return None
+
+    try:
+        drawer = rdMolDraw2D.MolDraw2DCairo(size, size)
+        options = drawer.drawOptions()
+        options.clearBackground = True
+        options.bondLineWidth = 2.0
+        options.padding = 0.15
+        drawer.DrawMolecule(molecule)
+        drawer.FinishDrawing()
+        image = Image.open(BytesIO(drawer.GetDrawingText())).convert("RGBA")
+    except Exception:
+        image = Draw.MolToImage(molecule, size=(size, size)).convert("RGBA")
+
+    data = np.array(image)
+    data[(data[:, :, :3] > 240).all(axis=2), 3] = 0
+    return Image.fromarray(data)
+
+
+def molecule_metadata(molecule_data: dict[str, Any]) -> tuple[str, str]:
+    """Return formula and formatted mass for a molecule entry."""
+    metadata = molecule_data.get("product_metadata") or molecule_data.get(
+        "reactant_metadata"
+    )
+    if metadata:
+        mass = metadata.get("mass", 0)
+        formula = str(metadata.get("chemical_formula", ""))
+        return formula, f"{round(float(mass), 1)} g/mol" if mass else ""
+
+    smiles = str(molecule_data.get("smiles", ""))
+    molecule = Chem.MolFromSmiles(smiles)
+    if molecule is None:
+        return smiles, "?"
+    formula = rdMolDescriptors.CalcMolFormula(molecule)
+    mass = round(Descriptors.ExactMolWt(molecule), 1)
+    return formula, f"{mass} g/mol"
+
+
+def get_font(size: int) -> Any:
+    """Load a common TrueType font or fall back to PIL's default font."""
+    for font_name in ("Arial.ttf", "arial.ttf", "DejaVuSans.ttf"):
+        try:
+            return ImageFont.truetype(font_name, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def draw_centered_text(
+    draw: ImageDraw.ImageDraw,
+    center_x: int,
+    y: int,
+    text: str,
+    font: ImageFont.ImageFont,
+) -> None:
+    """Draw centered text at a given y coordinate."""
+    bbox = draw.textbbox((0, 0), text, font=font)
+    width = bbox[2] - bbox[0]
+    draw.text((center_x - width // 2, y), text, fill=TEXT_COLOR, font=font)
+
+
+def max_x(node: PathwayNode) -> int:
+    """Return the rightmost node x coordinate in the tree."""
+    return max([node.x, *(max_x(child) for child in node.children)])
+
+
+def draw_edges(draw: ImageDraw.ImageDraw, node: PathwayNode) -> None:
+    """Draw curved connectors for a pathway tree."""
+    for child in node.children:
+        start_x, start_y = node.x, node.y
+        end_x, end_y = child.x, child.y
+        mid_x = (start_x + end_x) // 2
+        points = []
+        for index in range(31):
+            t = index / 30
+            u = 1 - t
+            curve_x = (
+                u**3 * start_x
+                + 3 * u**2 * t * mid_x
+                + 3 * u * t**2 * mid_x
+                + t**3 * end_x
+            )
+            curve_y = (
+                u**3 * start_y
+                + 3 * u**2 * t * start_y
+                + 3 * u * t**2 * end_y
+                + t**3 * end_y
+            )
+            points.append((int(curve_x), int(curve_y)))
+
+        for first, second in zip(points, points[1:]):
+            draw.line([first, second], fill=LINE_COLOR, width=2)
+        draw_edges(draw, child)
+
+
+def draw_node(
+    image: Image.Image,
+    draw: ImageDraw.ImageDraw,
+    node: PathwayNode,
+    label_font: ImageFont.ImageFont,
+    small_font: ImageFont.ImageFont,
+) -> None:
+    """Draw one pathway node and its descendants."""
+    radius = MAIN_RADIUS if node.is_target else SMALL_RADIUS
+    count = max(len(node.molecules), 1)
+    top_y = node.y - (count * MOLECULE_CELL_HEIGHT) // 2
+
+    draw_centered_text(draw, node.x, top_y - 24, node.label, label_font)
+    for index, molecule_data in enumerate(node.molecules):
+        center_y = top_y + index * MOLECULE_CELL_HEIGHT + MOLECULE_CELL_HEIGHT // 2
+        fill = TARGET_FILL if node.is_target else STEP_FILL
+        stroke = TARGET_STROKE if node.is_target else STEP_STROKE
+        draw.ellipse(
+            [
+                node.x - radius,
+                center_y - radius,
+                node.x + radius,
+                center_y + radius,
+            ],
+            fill=fill,
+            outline=stroke,
+            width=2,
+        )
+
+        smiles = str(molecule_data.get("smiles", ""))
+        molecule_size = int(radius * 1.5)
+        molecule_image = render_molecule(smiles, molecule_size + 40)
+        if molecule_image is not None:
+            molecule_image = molecule_image.resize(
+                (molecule_size, molecule_size),
+                Image.Resampling.LANCZOS,
+            )
+            image.paste(
+                molecule_image,
+                (node.x - molecule_size // 2, center_y - molecule_size // 2),
+                molecule_image,
+            )
+
+        formula, mass = molecule_metadata(molecule_data)
+        draw_centered_text(draw, node.x, center_y + radius + 6, mass, small_font)
+        draw_centered_text(draw, node.x, center_y + radius + 22, formula, small_font)
+
+    for child in node.children:
+        draw_node(image, draw, child, label_font, small_font)
+
+
+def visualize_pathway(result: dict[str, Any]) -> Image.Image:
+    """Render a formatted pathway dictionary as a PIL image.
+
+    Parameters
+    ----------
+    result : dict[str, Any]
+        Dictionary containing ``steps`` and ``dependencies`` keys.
+
+    Returns
+    -------
+    PIL.Image.Image
+        Rendered pathway image.
+    """
+    label_font = get_font(15)
+    small_font = get_font(13)
+    root = build_tree(result)
+    if root is None:
+        image = Image.new("RGB", (400, 200), BACKGROUND)
+        draw = ImageDraw.Draw(image)
+        draw_centered_text(draw, 200, 90, "No synthesis steps", label_font)
+        return image
+
+    tree_height = node_height(root)
+    canvas_height = tree_height + PADDING * 2
+    layout(root, PADDING + MAIN_RADIUS, PADDING, PADDING + tree_height)
+    canvas_width = max_x(root) + MAIN_RADIUS + PADDING + 60
+
+    image = Image.new("RGBA", (canvas_width, canvas_height), (*BACKGROUND, 255))
+    draw = ImageDraw.Draw(image)
+    draw_edges(draw, root)
+    draw_node(image, draw, root, label_font, small_font)
+    return image.convert("RGB")

--- a/docs/source/package/deepretro.algorithms.autosolve.rst
+++ b/docs/source/package/deepretro.algorithms.autosolve.rst
@@ -1,0 +1,30 @@
+deepretro.algorithms.autosolve
+==============================
+
+``AutoSolver`` provides a package-level orchestration layer for single-molecule
+retrosynthesis. It first attempts an AiZynthFinder route through
+``deepretro.utils.az.run_az``. When no template route is available, it calls the
+package LLM retrosynthesis pipeline, recursively solves returned precursors, and
+formats the resulting tree with ``deepretro.utils.parse.format_output``.
+
+Example
+-------
+
+.. code-block:: python
+
+   from deepretro import AutoSolver
+
+   solver = AutoSolver(
+       llm="anthropic/claude-opus-4-6:adv",
+       az_model="Pistachio_100+",
+       hallucination_mode="heuristic",
+   )
+   result = solver.solve("CC(=O)Oc1ccccc1C(=O)O")
+   print(result["solved"], len(result["steps"]))
+
+API Reference
+-------------
+
+.. automodule:: deepretro.algorithms.autosolve
+   :members:
+   :undoc-members:

--- a/docs/source/package/deepretro.rst
+++ b/docs/source/package/deepretro.rst
@@ -14,6 +14,8 @@ The package currently provides:
   handcrafted chemistry descriptors.
 - Domain-feature extraction helpers for product/reactant SMILES pairs.
 - AiZynthFinder wrappers for template-based route search.
+- ``AutoSolver`` orchestration that tries AiZynthFinder first and falls back to
+  the package LLM retrosynthesis pipeline.
 - Heuristic hallucination detection and scoring for retrosynthetic steps.
 - ML-based hallucination classification (XGBoost via DeepChem ``GBDTModel``).
 - Dataset loading with DeepChem ``DiskDataset`` sharding and stratified splitting.
@@ -62,6 +64,7 @@ Subpackages
    :maxdepth: 2
 
    deepretro.algorithms.hallucination_checker
+   deepretro.algorithms.autosolve
    deepretro.data.loader
    deepretro.models.hallucination_classifier
    deepretro.metadata

--- a/docs/source/package/deepretro.utils_pkg.rst
+++ b/docs/source/package/deepretro.utils_pkg.rst
@@ -47,7 +47,6 @@ Behavior highlights:
 
 - Auto-bypass for trivial/basic molecules via ``BASIC_MOLECULES`` and
   ``is_basic_molecule``.
-- Caching via ``src.cache.cache_results`` decorator.
 - Explicit process-local caching helpers live in ``deepretro.utils.cache`` when
   callers need in-memory caching without shared global state.
 - Returns route dictionaries with metadata and scores from AiZynthFinder.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,3 @@
+# Lessons
+
+- When porting `origin/autosolve`, keep protecting-group prompt support out of this PR. The user explicitly scoped it to a follow-up PR.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,38 @@
+# AutoSolver Package Port
+
+## Plan
+
+- [x] Create a new branch from `porting/metadata-llm`.
+- [x] Inspect `origin/autosolve` and identify stale or duplicated migration code.
+- [x] Port the AutoSolver public API into the `deepretro` package layout.
+- [x] Replace `src.*` imports and duplicated utilities with package-local modules.
+- [x] Clean implementation style to match current typed, lazy-import package standards.
+- [x] Add focused unit tests for solver behavior, validation, recursion, and image wiring.
+- [x] Run formatter, linter, type checker where practical, and targeted tests.
+- [x] Ask Claude Code to review the tests with `claude -p`.
+- [x] Push the branch and open a draft PR.
+
+## Success Criteria
+
+- `deepretro.AutoSolver` and `deepretro.algorithms.AutoSolver` import lazily.
+- AutoSolver can use AiZynthFinder results directly and LLM fallback when AZ fails.
+- Cycles, invalid SMILES, max-depth exits, and all-unsolved pathways are deterministic.
+- Tests do not require network calls, real LLM credentials, or AiZynthFinder model files.
+- The PR is draft and describes validation evidence plus known gaps.
+
+## Review
+
+- Ported AutoSolver without protecting-group prompt support; that scope is
+  reserved for a later PR.
+- Used the existing `deepretro.utils.llm.llm_pipeline` instead of adding the
+  stale duplicate `deepretro.algorithms.llm` module from `origin/autosolve`.
+- Added focused AutoSolver and hallucination helper tests, then expanded them
+  after Claude review to cover partial fallback trees and multi-reactant
+  pathways.
+- Validation passed:
+  - `PYTHONPATH=. uv run --project deepretro --extra dev python -m pytest deepretro/tests/test_autosolve.py deepretro/tests/test_hallucination_helpers.py`
+  - `PYTHONPATH=. uv run --project deepretro --extra dev python -m pytest deepretro/tests -m "not slow"`
+  - `PYTHONPATH=. uv run --project deepretro --extra dev ruff format --check ...`
+  - `PYTHONPATH=. uv run --project deepretro --extra dev ruff check ...`
+  - `PYTHONPATH=. uv run --project deepretro --extra dev ty check deepretro/algorithms/autosolve.py deepretro/models/hallucination_helpers.py deepretro/utils/visualize.py`
+  - `PYTHONPATH=. uv run --project deepretro --extra dev --extra docs sphinx-build -b html docs/source docs/_build/html`


### PR DESCRIPTION
## Description

Ports the useful autosolve branch content onto the current `deepretro` package API without copying the stale duplicate `deepretro.algorithms.llm` module. `AutoSolver` now exposes an AZ-first, LLM-fallback orchestration path through `deepretro.AutoSolver` and `deepretro.algorithms.AutoSolver`, using the existing `deepretro.utils.llm.llm_pipeline` and parser utilities.

Protecting-group prompt support is intentionally not included; it is reserved for a follow-up PR per scope update.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentations (modification for documents)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Validation

- `PYTHONPATH=. uv run --project deepretro --extra dev python -m pytest deepretro/tests/test_autosolve.py deepretro/tests/test_hallucination_helpers.py` -> 20 passed
- `PYTHONPATH=. uv run --project deepretro --extra dev python -m pytest deepretro/tests -m "not slow"` -> 178 passed, 2 skipped, 2 deselected
- `PYTHONPATH=. uv run --project deepretro --extra dev ruff format --check <touched files>` -> clean
- `PYTHONPATH=. uv run --project deepretro --extra dev ruff check <touched files>` -> clean
- `PYTHONPATH=. uv run --project deepretro --extra dev ty check deepretro/algorithms/autosolve.py deepretro/models/hallucination_helpers.py deepretro/utils/visualize.py` -> clean
- `PYTHONPATH=. uv run --project deepretro --extra dev --extra docs sphinx-build -b html docs/source docs/_build/html` -> build succeeded
- `claude -p` reviewed the new tests; actionable gaps were addressed for partial fallback, multi-reactant pathways, and helper edge cases.

## Not tested

- Live LLM credentials and real AiZynthFinder model execution for the full AutoSolver fallback path.