### PR TITLE
[Autosolve PR 1] Add hallucination helpers and autosolve foundations

### DIFF
--- a/deepretro/models/__init__.py
+++ b/deepretro/models/__init__.py
@@ -2,21 +2,26 @@
 
 from __future__ import annotations
 
+from deepretro.models.hallucination_helpers import (
+    build_ml_checker,
+    filter_with_checker,
+    resolve_hallucination,
+)
+
 __all__ = [
     "HallucinationClassifier",
     "build_ml_checker",
+    "filter_with_checker",
     "predict_single_reaction",
     "resolve_hallucination",
 ]
 
 
 def __getattr__(name: str):
+    # HallucinationClassifier and predict_single_reaction live in
+    # hallucination_classifier which pulls in deepchem — keep that lazy.
     if name in {"HallucinationClassifier", "predict_single_reaction"}:
         from deepretro.models import hallucination_classifier
 
         return getattr(hallucination_classifier, name)
-    if name in {"build_ml_checker", "resolve_hallucination"}:
-        from deepretro.models import hallucination_helpers
-
-        return getattr(hallucination_helpers, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/deepretro/models/__init__.py
+++ b/deepretro/models/__init__.py
@@ -1,8 +1,22 @@
 """Model wrappers for retrosynthesis ML tasks."""
 
-from deepretro.models.hallucination_classifier import (
-    HallucinationClassifier,
-    predict_single_reaction,
-)
+from __future__ import annotations
 
-__all__ = ["HallucinationClassifier", "predict_single_reaction"]
+__all__ = [
+    "HallucinationClassifier",
+    "build_ml_checker",
+    "predict_single_reaction",
+    "resolve_hallucination",
+]
+
+
+def __getattr__(name: str):
+    if name in {"HallucinationClassifier", "predict_single_reaction"}:
+        from deepretro.models import hallucination_classifier
+
+        return getattr(hallucination_classifier, name)
+    if name in {"build_ml_checker", "resolve_hallucination"}:
+        from deepretro.models import hallucination_helpers
+
+        return getattr(hallucination_helpers, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/deepretro/models/__init__.py
+++ b/deepretro/models/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from deepretro.models.hallucination_helpers import (
     build_ml_checker,
     filter_with_checker,
@@ -17,7 +19,35 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
+    """Lazily resolve deepchem-backed attributes (PEP 562 module hook).
+
+    ``HallucinationClassifier`` and ``predict_single_reaction`` live in
+    :mod:`deepretro.models.hallucination_classifier`, which imports deepchem.
+    Loading them lazily keeps ``import deepretro.models`` cheap for callers
+    that only need the lightweight hallucination helpers.
+
+    Parameters
+    ----------
+    name : str
+        Attribute name requested on the module.
+
+    Returns
+    -------
+    Any
+        The resolved attribute from ``hallucination_classifier``.
+
+    Raises
+    ------
+    AttributeError
+        If *name* is not a lazily exported attribute.
+
+    Examples
+    --------
+    >>> from deepretro import models
+    >>> models.HallucinationClassifier  # doctest: +SKIP
+    <class 'deepretro.models.hallucination_classifier.HallucinationClassifier'>
+    """
     # HallucinationClassifier and predict_single_reaction live in
     # hallucination_classifier which pulls in deepchem — keep that lazy.
     if name in {"HallucinationClassifier", "predict_single_reaction"}:

--- a/deepretro/models/hallucination_helpers.py
+++ b/deepretro/models/hallucination_helpers.py
@@ -1,0 +1,139 @@
+"""Helpers for optional hallucination filtering in retrosynthesis pipelines."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from deepretro.utils.llm_helpers import Pathway
+from deepretro.utils.typing import HallucinationChecker
+
+
+def _as_pathway(candidate: Pathway | str) -> Pathway:
+    """Normalize one candidate into a pathway list."""
+    return [candidate] if isinstance(candidate, str) else list(candidate)
+
+
+def build_ml_checker(classifier: Any) -> HallucinationChecker:
+    """Wrap a classifier in the checker interface used by ``AutoSolver``.
+
+    Parameters
+    ----------
+    classifier : Any
+        Object exposing ``predict_single(product_smiles, reactants_smiles)``.
+
+    Returns
+    -------
+    HallucinationChecker
+        Callable returning ``(200, retained_pathways)``.
+    """
+
+    def _checker(product: str, pathways: list[Pathway]) -> tuple[int, list[Pathway]]:
+        from deepretro.utils.utils_molecule import is_valid_smiles
+
+        retained: list[Pathway] = []
+        for candidate in pathways:
+            pathway = _as_pathway(candidate)
+            reactants_smiles = ".".join(pathway)
+            if not is_valid_smiles(reactants_smiles):
+                continue
+
+            prediction = classifier.predict_single(product, reactants_smiles)
+            if not bool(prediction.get("is_hallucination", True)):
+                retained.append(pathway)
+
+        return 200, retained
+
+    return _checker
+
+
+def filter_with_checker(
+    product: str,
+    pathways: list[Pathway],
+    explanations: Iterable[str],
+    confidence: Iterable[float],
+    checker: HallucinationChecker | None,
+) -> tuple[list[Pathway], list[str], list[float]]:
+    """Filter pathways and keep explanations/confidence aligned.
+
+    Parameters
+    ----------
+    product : str
+        Product molecule SMILES.
+    pathways : list[list[str]]
+        Candidate precursor pathways.
+    explanations : Iterable[str]
+        Explanations aligned with ``pathways``.
+    confidence : Iterable[float]
+        Confidence scores aligned with ``pathways``.
+    checker : HallucinationChecker or None
+        Optional pathway filter.
+
+    Returns
+    -------
+    tuple[list[list[str]], list[str], list[float]]
+        Retained pathways with aligned metadata.
+    """
+    if checker is None or not pathways:
+        return pathways, list(explanations), list(confidence)
+
+    status, retained_pathways = checker(product, pathways)
+    if status != 200:
+        return [], [], []
+
+    retained_explanations: list[str] = []
+    retained_confidence: list[float] = []
+    available = list(zip(pathways, explanations, confidence))
+    for retained in retained_pathways:
+        for index, (pathway, explanation, score) in enumerate(available):
+            if pathway == retained:
+                retained_explanations.append(explanation)
+                retained_confidence.append(float(score))
+                available.pop(index)
+                break
+
+    return retained_pathways, retained_explanations, retained_confidence
+
+
+def resolve_hallucination(
+    mode: str,
+    classifier: str | Path | Any | None,
+) -> HallucinationChecker | None:
+    """Resolve an AutoSolver hallucination mode into a checker callable.
+
+    Parameters
+    ----------
+    mode : str
+        One of ``"heuristic"``, ``"ml"``, or ``"none"``.
+    classifier : str, Path, object, or None
+        Saved classifier directory or classifier object for ``"ml"`` mode.
+
+    Returns
+    -------
+    HallucinationChecker or None
+        ``None`` for ``"none"`` and ``"heuristic"`` because the built-in
+        heuristic path is handled by ``deepretro.utils.llm.llm_pipeline``.
+    """
+    normalized_mode = mode.lower()
+    if normalized_mode in {"none", "heuristic"}:
+        return None
+    if normalized_mode != "ml":
+        raise ValueError(
+            f"hallucination_mode must be 'heuristic', 'ml', or 'none' (got {mode!r})"
+        )
+
+    if isinstance(classifier, (str, Path)):
+        from deepretro.models.hallucination_classifier import HallucinationClassifier
+
+        loaded_classifier = HallucinationClassifier()
+        loaded_classifier.load(str(classifier))
+        return build_ml_checker(loaded_classifier)
+
+    if hasattr(classifier, "predict_single"):
+        return build_ml_checker(classifier)
+
+    raise ValueError(
+        "hallucination_mode='ml' requires a HallucinationClassifier instance "
+        "or path to a saved classifier"
+    )

--- a/deepretro/models/hallucination_helpers.py
+++ b/deepretro/models/hallucination_helpers.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from deepretro.utils.llm_helpers import Pathway
 from deepretro.utils.typing import HallucinationChecker
+from deepretro.utils.utils_molecule import is_valid_smiles
 
 
 def _as_pathway(candidate: Pathway | str) -> Pathway:
@@ -30,8 +31,6 @@ def build_ml_checker(classifier: Any) -> HallucinationChecker:
     """
 
     def _checker(product: str, pathways: list[Pathway]) -> tuple[int, list[Pathway]]:
-        from deepretro.utils.utils_molecule import is_valid_smiles
-
         retained: list[Pathway] = []
         for candidate in pathways:
             pathway = _as_pathway(candidate)
@@ -82,18 +81,20 @@ def filter_with_checker(
     if status != 200:
         return [], [], []
 
-    retained_explanations: list[str] = []
-    retained_confidence: list[float] = []
+    matched_pathways: list[Pathway] = []
+    matched_explanations: list[str] = []
+    matched_confidence: list[float] = []
     available = list(zip(pathways, explanations, confidence))
     for retained in retained_pathways:
         for index, (pathway, explanation, score) in enumerate(available):
             if pathway == retained:
-                retained_explanations.append(explanation)
-                retained_confidence.append(float(score))
+                matched_pathways.append(retained)
+                matched_explanations.append(explanation)
+                matched_confidence.append(float(score))
                 available.pop(index)
                 break
 
-    return retained_pathways, retained_explanations, retained_confidence
+    return matched_pathways, matched_explanations, matched_confidence
 
 
 def resolve_hallucination(

--- a/deepretro/models/hallucination_helpers.py
+++ b/deepretro/models/hallucination_helpers.py
@@ -41,6 +41,18 @@ def build_ml_checker(classifier: HallucinationPredictor) -> HallucinationChecker
     ------
     TypeError
         If *classifier* does not expose ``predict_single``.
+
+    Examples
+    --------
+    >>> class MyClassifier:
+    ...     def predict_single(self, product, reactants):
+    ...         return {"is_hallucination": False}
+    >>> checker = build_ml_checker(MyClassifier())
+    >>> status, retained = checker("CC(=O)Oc1ccccc1C(=O)O", [["OC(=O)c1ccccc1O"]])
+    >>> status
+    200
+    >>> retained
+    [['OC(=O)c1ccccc1O']]
     """
     if not callable(getattr(classifier, "predict_single", None)):
         raise TypeError(
@@ -99,6 +111,20 @@ def filter_with_checker(
         If ``pathways``, ``explanations``, and ``confidence`` have
         different lengths, or if the checker returns a pathway not present
         in the original input.
+
+    Examples
+    --------
+    >>> pathways, expl, conf = filter_with_checker(
+    ...     "CC(=O)Oc1ccccc1C(=O)O",
+    ...     [["OC(=O)c1ccccc1O"], ["CC(=O)O"]],
+    ...     ["hydrolysis", "deacetylation"],
+    ...     [0.3, 0.9],
+    ...     None,
+    ... )
+    >>> pathways
+    [['OC(=O)c1ccccc1O'], ['CC(=O)O']]
+    >>> conf
+    [0.3, 0.9]
     """
     explanation_list = list(explanations)
     confidence_list = list(confidence)
@@ -163,6 +189,19 @@ def resolve_hallucination(
     ValueError
         If *mode* is not one of the three valid options, or if ``"ml"``
         mode is requested without a valid classifier.
+
+    Examples
+    --------
+    >>> resolve_hallucination("none", None) is None
+    True
+    >>> resolve_hallucination("heuristic", None) is None
+    True
+    >>> class MyClassifier:
+    ...     def predict_single(self, product, reactants):
+    ...         return {"is_hallucination": False}
+    >>> checker = resolve_hallucination("ml", MyClassifier())
+    >>> callable(checker)
+    True
     """
     normalized_mode = mode.lower()
     if normalized_mode in {"none", "heuristic"}:

--- a/deepretro/models/hallucination_helpers.py
+++ b/deepretro/models/hallucination_helpers.py
@@ -4,11 +4,20 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from deepretro.utils.llm_helpers import Pathway
 from deepretro.utils.typing import HallucinationChecker
 from deepretro.utils.utils_molecule import is_valid_smiles
+
+
+@runtime_checkable
+class HallucinationPredictor(Protocol):
+    """Protocol for hallucination classifiers used by :func:`build_ml_checker`."""
+
+    def predict_single(
+        self, product_smiles: str, reactants_smiles: str
+    ) -> dict[str, Any]: ...
 
 
 def _as_pathway(candidate: Pathway | str) -> Pathway:
@@ -16,19 +25,28 @@ def _as_pathway(candidate: Pathway | str) -> Pathway:
     return [candidate] if isinstance(candidate, str) else list(candidate)
 
 
-def build_ml_checker(classifier: Any) -> HallucinationChecker:
+def build_ml_checker(classifier: HallucinationPredictor) -> HallucinationChecker:
     """Wrap a classifier in the checker interface used by ``AutoSolver``.
 
     Parameters
     ----------
-    classifier : Any
+    classifier : HallucinationPredictor
         Object exposing ``predict_single(product_smiles, reactants_smiles)``.
 
     Returns
     -------
     HallucinationChecker
         Callable returning ``(200, retained_pathways)``.
+
+    Raises
+    ------
+    TypeError
+        If *classifier* does not expose ``predict_single``.
     """
+    if not callable(getattr(classifier, "predict_single", None)):
+        raise TypeError(
+            "classifier must expose predict_single(product_smiles, reactants_smiles)"
+        )
 
     def _checker(product: str, pathways: list[Pathway]) -> tuple[int, list[Pathway]]:
         retained: list[Pathway] = []
@@ -39,7 +57,7 @@ def build_ml_checker(classifier: Any) -> HallucinationChecker:
                 continue
 
             prediction = classifier.predict_single(product, reactants_smiles)
-            if not bool(prediction.get("is_hallucination", True)):
+            if prediction.get("is_hallucination") is False:
                 retained.append(pathway)
 
         return 200, retained
@@ -72,34 +90,58 @@ def filter_with_checker(
     Returns
     -------
     tuple[list[list[str]], list[str], list[float]]
-        Retained pathways with aligned metadata.
+        Retained pathways with aligned metadata. Only pathways present in
+        the original input are included; unknown pathways returned by the
+        checker raise ``ValueError``.
+
+    Raises
+    ------
+    ValueError
+        If ``pathways``, ``explanations``, and ``confidence`` have
+        different lengths, or if the checker returns a pathway not present
+        in the original input.
     """
+    explanation_list = list(explanations)
+    confidence_list = list(confidence)
+    if len(pathways) != len(explanation_list) or len(pathways) != len(confidence_list):
+        raise ValueError(
+            f"pathways ({len(pathways)}), explanations ({len(explanation_list)}), "
+            f"and confidence ({len(confidence_list)}) must have the same length"
+        )
+
     if checker is None or not pathways:
-        return pathways, list(explanations), list(confidence)
+        return pathways, explanation_list, confidence_list
 
     status, retained_pathways = checker(product, pathways)
     if status != 200:
         return [], [], []
 
+    available = list(zip(pathways, explanation_list, confidence_list))
     matched_pathways: list[Pathway] = []
     matched_explanations: list[str] = []
     matched_confidence: list[float] = []
-    available = list(zip(pathways, explanations, confidence))
+
     for retained in retained_pathways:
+        found = False
         for index, (pathway, explanation, score) in enumerate(available):
             if pathway == retained:
                 matched_pathways.append(retained)
                 matched_explanations.append(explanation)
                 matched_confidence.append(float(score))
                 available.pop(index)
+                found = True
                 break
+        if not found:
+            raise ValueError(
+                f"Checker returned pathway {retained!r} not present in original input"
+            )
 
     return matched_pathways, matched_explanations, matched_confidence
 
 
 def resolve_hallucination(
     mode: str,
-    classifier: str | Path | Any | None,
+    classifier: str | Path | HallucinationPredictor | None,
 ) -> HallucinationChecker | None:
     """Resolve an AutoSolver hallucination mode into a checker callable.
 
@@ -107,7 +149,7 @@ def resolve_hallucination(
     ----------
     mode : str
         One of ``"heuristic"``, ``"ml"``, or ``"none"``.
-    classifier : str, Path, object, or None
+    classifier : str, Path, HallucinationPredictor, or None
         Saved classifier directory or classifier object for ``"ml"`` mode.
 
     Returns
@@ -115,6 +157,12 @@ def resolve_hallucination(
     HallucinationChecker or None
         ``None`` for ``"none"`` and ``"heuristic"`` because the built-in
         heuristic path is handled by ``deepretro.utils.llm.llm_pipeline``.
+
+    Raises
+    ------
+    ValueError
+        If *mode* is not one of the three valid options, or if ``"ml"``
+        mode is requested without a valid classifier.
     """
     normalized_mode = mode.lower()
     if normalized_mode in {"none", "heuristic"}:
@@ -131,7 +179,7 @@ def resolve_hallucination(
         loaded_classifier.load(str(classifier))
         return build_ml_checker(loaded_classifier)
 
-    if hasattr(classifier, "predict_single"):
+    if isinstance(classifier, HallucinationPredictor):
         return build_ml_checker(classifier)
 
     raise ValueError(

--- a/deepretro/models/hallucination_helpers.py
+++ b/deepretro/models/hallucination_helpers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from deepretro.utils.llm_helpers import Pathway
@@ -141,7 +140,7 @@ def filter_with_checker(
 
 def resolve_hallucination(
     mode: str,
-    classifier: str | Path | HallucinationPredictor | None,
+    classifier: HallucinationPredictor | None,
 ) -> HallucinationChecker | None:
     """Resolve an AutoSolver hallucination mode into a checker callable.
 
@@ -149,8 +148,9 @@ def resolve_hallucination(
     ----------
     mode : str
         One of ``"heuristic"``, ``"ml"``, or ``"none"``.
-    classifier : str, Path, HallucinationPredictor, or None
-        Saved classifier directory or classifier object for ``"ml"`` mode.
+    classifier : HallucinationPredictor or None
+        Classifier object exposing ``predict_single`` for ``"ml"`` mode.
+        The caller is responsible for loading the model before passing it.
 
     Returns
     -------
@@ -172,17 +172,10 @@ def resolve_hallucination(
             f"hallucination_mode must be 'heuristic', 'ml', or 'none' (got {mode!r})"
         )
 
-    if isinstance(classifier, (str, Path)):
-        from deepretro.models.hallucination_classifier import HallucinationClassifier
-
-        loaded_classifier = HallucinationClassifier()
-        loaded_classifier.load(str(classifier))
-        return build_ml_checker(loaded_classifier)
-
     if isinstance(classifier, HallucinationPredictor):
         return build_ml_checker(classifier)
 
     raise ValueError(
-        "hallucination_mode='ml' requires a HallucinationClassifier instance "
-        "or path to a saved classifier"
+        "hallucination_mode='ml' requires a classifier object exposing "
+        "predict_single(product_smiles, reactants_smiles)"
     )

--- a/deepretro/tests/test_hallucination_helpers.py
+++ b/deepretro/tests/test_hallucination_helpers.py
@@ -1,0 +1,140 @@
+"""Tests for hallucination checker adapter helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import call
+
+import pytest
+
+from deepretro.models.hallucination_helpers import (
+    build_ml_checker,
+    filter_with_checker,
+    resolve_hallucination,
+)
+
+
+def test_build_ml_checker_keeps_non_hallucinated_pathways(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ML checker keeps pathways whose classifier prediction is clean."""
+    classifier = MagicMock()
+    classifier.predict_single.side_effect = [
+        {"is_hallucination": True},
+        {"is_hallucination": False},
+    ]
+    monkeypatch.setattr(
+        "deepretro.utils.utils_molecule.is_valid_smiles",
+        lambda smiles: True,
+    )
+
+    status, retained = build_ml_checker(classifier)("CCO", [["CC"], ["CO"]])
+
+    assert status == 200
+    assert retained == [["CO"]]
+    classifier.predict_single.assert_has_calls(
+        [
+            call("CCO", "CC"),
+            call("CCO", "CO"),
+        ]
+    )
+
+
+def test_build_ml_checker_drops_invalid_reactant_sets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid joined reactant SMILES are ignored before classifier calls."""
+    classifier = MagicMock()
+    monkeypatch.setattr(
+        "deepretro.utils.utils_molecule.is_valid_smiles",
+        lambda smiles: False,
+    )
+
+    status, retained = build_ml_checker(classifier)("CCO", [["not-valid"]])
+
+    assert status == 200
+    assert retained == []
+    classifier.predict_single.assert_not_called()
+
+
+def test_filter_with_checker_preserves_explanation_and_confidence_alignment() -> None:
+    """Filtering retains metadata aligned to the surviving pathway."""
+
+    def checker(product: str, pathways: list[list[str]]) -> tuple[int, list[list[str]]]:
+        assert product == "CCO"
+        assert pathways == [["CC"], ["CO"]]
+        return 200, [["CO"]]
+
+    pathways, explanations, confidence = filter_with_checker(
+        "CCO",
+        [["CC"], ["CO"]],
+        ["first", "second"],
+        [0.1, 0.9],
+        checker,
+    )
+
+    assert pathways == [["CO"]]
+    assert explanations == ["second"]
+    assert confidence == [0.9]
+
+
+def test_filter_with_checker_short_circuits_without_checker() -> None:
+    """No checker leaves pathways and metadata unchanged."""
+    pathways, explanations, confidence = filter_with_checker(
+        "CCO",
+        [["CC"], ["CO"]],
+        ["first", "second"],
+        [0.1, 0.9],
+        None,
+    )
+
+    assert pathways == [["CC"], ["CO"]]
+    assert explanations == ["first", "second"]
+    assert confidence == [0.1, 0.9]
+
+
+def test_filter_with_checker_returns_empty_on_checker_failure() -> None:
+    """Non-200 checker status drops all aligned metadata."""
+
+    def checker(product: str, pathways: list[list[str]]) -> tuple[int, list[list[str]]]:
+        return 500, pathways
+
+    assert filter_with_checker("CCO", [["CC"]], ["first"], [0.1], checker) == (
+        [],
+        [],
+        [],
+    )
+
+
+def test_filter_with_checker_handles_duplicate_pathways_in_order() -> None:
+    """Duplicate retained pathways consume metadata entries one at a time."""
+
+    def checker(product: str, pathways: list[list[str]]) -> tuple[int, list[list[str]]]:
+        return 200, [["CC"], ["CC"]]
+
+    pathways, explanations, confidence = filter_with_checker(
+        "CCO",
+        [["CC"], ["CC"], ["CO"]],
+        ["first", "second", "third"],
+        [0.1, 0.2, 0.3],
+        checker,
+    )
+
+    assert pathways == [["CC"], ["CC"]]
+    assert explanations == ["first", "second"]
+    assert confidence == [0.1, 0.2]
+
+
+def test_resolve_hallucination_modes() -> None:
+    """Mode resolution is explicit and validates ML classifier inputs."""
+    assert resolve_hallucination("none", None) is None
+    assert resolve_hallucination("heuristic", None) is None
+
+    classifier = MagicMock()
+    classifier.predict_single.return_value = {"is_hallucination": False}
+    assert callable(resolve_hallucination("ml", classifier))
+
+    with pytest.raises(ValueError, match="hallucination_mode"):
+        resolve_hallucination("unknown", None)
+    with pytest.raises(ValueError, match="requires"):
+        resolve_hallucination("ml", None)

--- a/deepretro/tests/test_hallucination_helpers.py
+++ b/deepretro/tests/test_hallucination_helpers.py
@@ -49,6 +49,7 @@ class SelectiveClassifier:
 
 class TestBuildMlChecker:
     def test_retains_clean_aspirin_precursors(self) -> None:
+        """Clean precursors are all retained and the classifier is called per pathway."""
         classifier = StubClassifier()
         checker = build_ml_checker(classifier)
 
@@ -62,6 +63,7 @@ class TestBuildMlChecker:
         ]
 
     def test_removes_hallucinated_pathway(self) -> None:
+        """A pathway flagged as hallucinated is dropped."""
         classifier = SelectiveClassifier(hallucinated={SALICYLIC_ACID})
         checker = build_ml_checker(classifier)
 
@@ -71,6 +73,7 @@ class TestBuildMlChecker:
         assert retained == [[ACETIC_ACID]]
 
     def test_skips_invalid_smiles_without_calling_classifier(self) -> None:
+        """Invalid SMILES are skipped without invoking the classifier."""
         classifier = StubClassifier()
         checker = build_ml_checker(classifier)
 
@@ -81,6 +84,7 @@ class TestBuildMlChecker:
         assert classifier.calls == []
 
     def test_joins_multi_reactant_pathway_with_dot(self) -> None:
+        """Multi-reactant pathways are dot-joined before classification."""
         classifier = StubClassifier()
         checker = build_ml_checker(classifier)
 
@@ -136,12 +140,15 @@ class TestBuildMlChecker:
         assert classifier.calls == [(ASPIRIN, SALICYLIC_ACID)]
 
     def test_rejects_classifier_without_predict_single(self) -> None:
+        """A classifier lacking predict_single raises TypeError."""
         with pytest.raises(TypeError, match="predict_single"):
             build_ml_checker(object())  # type: ignore[arg-type]
 
 
 class TestFilterWithChecker:
     def test_retains_aligned_metadata_after_filtering(self) -> None:
+        """Explanations and confidence stay aligned with retained pathways."""
+
         def keep_second(
             product: str, pathways: list[list[str]]
         ) -> tuple[int, list[list[str]]]:
@@ -160,6 +167,7 @@ class TestFilterWithChecker:
         assert confidence == [0.9]
 
     def test_none_checker_passes_through(self) -> None:
+        """A None checker returns the inputs unchanged."""
         pathways, explanations, confidence = filter_with_checker(
             ASPIRIN,
             [[SALICYLIC_ACID], [ACETIC_ACID]],
@@ -173,6 +181,8 @@ class TestFilterWithChecker:
         assert confidence == [0.1, 0.9]
 
     def test_non_200_status_drops_everything(self) -> None:
+        """A non-200 checker status drops all pathways and metadata."""
+
         def fail(
             product: str, pathways: list[list[str]]
         ) -> tuple[int, list[list[str]]]:
@@ -183,6 +193,8 @@ class TestFilterWithChecker:
         assert result == ([], [], [])
 
     def test_duplicate_pathways_consume_metadata_in_order(self) -> None:
+        """Duplicate retained pathways consume their metadata in order."""
+
         def return_dupes(
             product: str, pathways: list[list[str]]
         ) -> tuple[int, list[list[str]]]:
@@ -201,6 +213,7 @@ class TestFilterWithChecker:
         assert confidence == [0.1, 0.2]
 
     def test_empty_pathways_returns_empty(self) -> None:
+        """Empty inputs return empty outputs."""
         pathways, explanations, confidence = filter_with_checker(
             ASPIRIN, [], [], [], None
         )
@@ -233,6 +246,7 @@ class TestFilterWithChecker:
             )
 
     def test_shorter_confidence_raises(self) -> None:
+        """A shorter confidence list raises a length-mismatch ValueError."""
         with pytest.raises(ValueError, match="same length"):
             filter_with_checker(
                 ASPIRIN,
@@ -245,20 +259,25 @@ class TestFilterWithChecker:
 
 class TestResolveHallucination:
     def test_none_mode(self) -> None:
+        """'none' mode resolves to no checker."""
         assert resolve_hallucination("none", None) is None
 
     def test_heuristic_mode(self) -> None:
+        """'heuristic' mode resolves to None (handled by the LLM pipeline)."""
         assert resolve_hallucination("heuristic", None) is None
 
     def test_case_insensitive(self) -> None:
+        """Mode strings are matched case-insensitively."""
         assert resolve_hallucination("NONE", None) is None
         assert resolve_hallucination("Heuristic", None) is None
 
     def test_ml_mode_without_classifier_raises(self) -> None:
+        """'ml' mode without a classifier raises ValueError."""
         with pytest.raises(ValueError, match="requires"):
             resolve_hallucination("ml", None)
 
     def test_unknown_mode_raises(self) -> None:
+        """An unrecognized mode raises ValueError."""
         with pytest.raises(ValueError, match="hallucination_mode"):
             resolve_hallucination("unknown", None)
 

--- a/deepretro/tests/test_hallucination_helpers.py
+++ b/deepretro/tests/test_hallucination_helpers.py
@@ -112,6 +112,29 @@ class TestBuildMlChecker:
         assert status == 200
         assert retained == []
 
+    def test_normalizes_string_pathway_to_list(self) -> None:
+        """A pathway given as a dot-joined string is normalized to a list."""
+        classifier = StubClassifier()
+        checker = build_ml_checker(classifier)
+        combined = f"{SALICYLIC_ACID}.{ACETIC_ACID}"
+
+        status, retained = checker(ASPIRIN, [combined])
+
+        assert status == 200
+        assert retained == [[combined]]
+        assert classifier.calls == [(ASPIRIN, combined)]
+
+    def test_skips_invalid_pathway_but_keeps_valid_ones(self) -> None:
+        """An invalid pathway is skipped without dropping the valid ones."""
+        classifier = StubClassifier()
+        checker = build_ml_checker(classifier)
+
+        status, retained = checker(ASPIRIN, [["not>>>valid"], [SALICYLIC_ACID]])
+
+        assert status == 200
+        assert retained == [[SALICYLIC_ACID]]
+        assert classifier.calls == [(ASPIRIN, SALICYLIC_ACID)]
+
     def test_rejects_classifier_without_predict_single(self) -> None:
         with pytest.raises(TypeError, match="predict_single"):
             build_ml_checker(object())  # type: ignore[arg-type]

--- a/deepretro/tests/test_hallucination_helpers.py
+++ b/deepretro/tests/test_hallucination_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 
 import pytest
 
@@ -11,7 +12,6 @@ from deepretro.models.hallucination_helpers import (
     resolve_hallucination,
 )
 
-# Real molecule SMILES for meaningful tests
 ASPIRIN = "CC(=O)Oc1ccccc1C(=O)O"
 SALICYLIC_ACID = "OC(=O)c1ccccc1O"
 ACETIC_ACID = "CC(=O)O"
@@ -19,56 +19,50 @@ PARACETAMOL = "CC(=O)Nc1ccc(O)cc1"
 PARA_AMINOPHENOL = "Nc1ccc(O)cc1"
 
 
-# ---------------------------------------------------------------------------
-# Classifier test doubles — injected, not mocked
-# ---------------------------------------------------------------------------
+class StubClassifier:
+    """Configurable classifier double that records calls."""
 
-
-class _AlwaysCleanClassifier:
-    """Classifier that marks every reaction as non-hallucinated."""
-
-    def __init__(self) -> None:
+    def __init__(self, responses: list[dict[str, Any]] | None = None) -> None:
+        self.responses = list(responses) if responses else []
         self.calls: list[tuple[str, str]] = []
 
-    def predict_single(self, product: str, reactants: str) -> dict[str, bool]:
-        self.calls.append((product, reactants))
+    def predict_single(
+        self, product_smiles: str, reactants_smiles: str
+    ) -> dict[str, Any]:
+        self.calls.append((product_smiles, reactants_smiles))
+        if self.responses:
+            return self.responses.pop(0)
         return {"is_hallucination": False}
 
 
-class _SelectiveClassifier:
-    """Classifier that marks specific reactants as hallucinated."""
+class SelectiveClassifier:
+    """Classifier that flags specific reactant SMILES as hallucinated."""
 
-    def __init__(self, hallucinated_reactants: set[str]) -> None:
-        self.hallucinated = hallucinated_reactants
-        self.calls: list[tuple[str, str]] = []
+    def __init__(self, hallucinated: set[str]) -> None:
+        self.hallucinated = hallucinated
 
-    def predict_single(self, product: str, reactants: str) -> dict[str, bool]:
-        self.calls.append((product, reactants))
-        return {"is_hallucination": reactants in self.hallucinated}
-
-
-# ---------------------------------------------------------------------------
-# build_ml_checker tests
-# ---------------------------------------------------------------------------
+    def predict_single(
+        self, product_smiles: str, reactants_smiles: str
+    ) -> dict[str, bool]:
+        return {"is_hallucination": reactants_smiles in self.hallucinated}
 
 
 class TestBuildMlChecker:
-    def test_keeps_non_hallucinated_aspirin_precursors(self) -> None:
-        """Both real precursors pass the classifier — both retained."""
-        classifier = _AlwaysCleanClassifier()
+    def test_retains_clean_aspirin_precursors(self) -> None:
+        classifier = StubClassifier()
         checker = build_ml_checker(classifier)
 
         status, retained = checker(ASPIRIN, [[SALICYLIC_ACID], [ACETIC_ACID]])
 
         assert status == 200
         assert retained == [[SALICYLIC_ACID], [ACETIC_ACID]]
-        assert len(classifier.calls) == 2
-        assert classifier.calls[0] == (ASPIRIN, SALICYLIC_ACID)
-        assert classifier.calls[1] == (ASPIRIN, ACETIC_ACID)
+        assert classifier.calls == [
+            (ASPIRIN, SALICYLIC_ACID),
+            (ASPIRIN, ACETIC_ACID),
+        ]
 
-    def test_filters_hallucinated_pathway(self) -> None:
-        """Classifier flags one precursor — only the clean one survives."""
-        classifier = _SelectiveClassifier(hallucinated_reactants={SALICYLIC_ACID})
+    def test_removes_hallucinated_pathway(self) -> None:
+        classifier = SelectiveClassifier(hallucinated={SALICYLIC_ACID})
         checker = build_ml_checker(classifier)
 
         status, retained = checker(ASPIRIN, [[SALICYLIC_ACID], [ACETIC_ACID]])
@@ -76,9 +70,8 @@ class TestBuildMlChecker:
         assert status == 200
         assert retained == [[ACETIC_ACID]]
 
-    def test_drops_invalid_smiles_before_classifier(self) -> None:
-        """Invalid SMILES are filtered out before reaching the classifier."""
-        classifier = _AlwaysCleanClassifier()
+    def test_skips_invalid_smiles_without_calling_classifier(self) -> None:
+        classifier = StubClassifier()
         checker = build_ml_checker(classifier)
 
         status, retained = checker(ASPIRIN, [["not>>>valid"]])
@@ -87,42 +80,46 @@ class TestBuildMlChecker:
         assert retained == []
         assert classifier.calls == []
 
-    def test_missing_hallucination_key_defaults_to_filtered(self) -> None:
-        """Classifier returning no is_hallucination key treats pathway as hallucinated."""
-
-        class _NoKeyClassifier:
-            def predict_single(self, product: str, reactants: str) -> dict:
-                return {"confidence": 0.5}
-
-        checker = build_ml_checker(_NoKeyClassifier())
-        status, retained = checker(ASPIRIN, [[SALICYLIC_ACID]])
-
-        assert status == 200
-        assert retained == []
-
-    def test_multi_reactant_pathway_joins_with_dot(self) -> None:
-        """Multiple reactants in one pathway are joined with '.' for the classifier."""
-        classifier = _AlwaysCleanClassifier()
+    def test_joins_multi_reactant_pathway_with_dot(self) -> None:
+        classifier = StubClassifier()
         checker = build_ml_checker(classifier)
 
         status, retained = checker(PARACETAMOL, [[PARA_AMINOPHENOL, ACETIC_ACID]])
 
         assert status == 200
         assert retained == [[PARA_AMINOPHENOL, ACETIC_ACID]]
-        expected_joined = f"{PARA_AMINOPHENOL}.{ACETIC_ACID}"
-        assert classifier.calls == [(PARACETAMOL, expected_joined)]
+        assert classifier.calls == [
+            (PARACETAMOL, f"{PARA_AMINOPHENOL}.{ACETIC_ACID}"),
+        ]
 
+    def test_missing_key_defaults_to_hallucinated(self) -> None:
+        """Classifier returning no is_hallucination key is treated as hallucinated."""
+        classifier = StubClassifier(responses=[{"confidence": 0.5}])
+        checker = build_ml_checker(classifier)
 
-# ---------------------------------------------------------------------------
-# filter_with_checker tests
-# ---------------------------------------------------------------------------
+        status, retained = checker(ASPIRIN, [[SALICYLIC_ACID]])
+
+        assert status == 200
+        assert retained == []
+
+    def test_none_value_treated_as_hallucinated(self) -> None:
+        """is_hallucination=None is not the same as False."""
+        classifier = StubClassifier(responses=[{"is_hallucination": None}])
+        checker = build_ml_checker(classifier)
+
+        status, retained = checker(ASPIRIN, [[SALICYLIC_ACID]])
+
+        assert status == 200
+        assert retained == []
+
+    def test_rejects_classifier_without_predict_single(self) -> None:
+        with pytest.raises(TypeError, match="predict_single"):
+            build_ml_checker(object())  # type: ignore[arg-type]
 
 
 class TestFilterWithChecker:
-    def test_preserves_alignment_after_filtering(self) -> None:
-        """Retained pathway keeps its original explanation and confidence."""
-
-        def keeps_only_second(
+    def test_retains_aligned_metadata_after_filtering(self) -> None:
+        def keep_second(
             product: str, pathways: list[list[str]]
         ) -> tuple[int, list[list[str]]]:
             return 200, [pathways[1]]
@@ -132,15 +129,14 @@ class TestFilterWithChecker:
             [[SALICYLIC_ACID], [ACETIC_ACID]],
             ["hydrolysis", "deacetylation"],
             [0.3, 0.9],
-            keeps_only_second,
+            keep_second,
         )
 
         assert pathways == [[ACETIC_ACID]]
         assert explanations == ["deacetylation"]
         assert confidence == [0.9]
 
-    def test_no_checker_passes_through(self) -> None:
-        """None checker returns everything unchanged."""
+    def test_none_checker_passes_through(self) -> None:
         pathways, explanations, confidence = filter_with_checker(
             ASPIRIN,
             [[SALICYLIC_ACID], [ACETIC_ACID]],
@@ -154,23 +150,17 @@ class TestFilterWithChecker:
         assert confidence == [0.1, 0.9]
 
     def test_non_200_status_drops_everything(self) -> None:
-        """Non-200 checker status discards all pathways and metadata."""
-
-        def fails(
+        def fail(
             product: str, pathways: list[list[str]]
         ) -> tuple[int, list[list[str]]]:
             return 500, pathways
 
-        result = filter_with_checker(
-            ASPIRIN, [[SALICYLIC_ACID]], ["only"], [0.8], fails
-        )
+        result = filter_with_checker(ASPIRIN, [[SALICYLIC_ACID]], ["only"], [0.8], fail)
 
         assert result == ([], [], [])
 
     def test_duplicate_pathways_consume_metadata_in_order(self) -> None:
-        """When checker returns duplicates, metadata is consumed sequentially."""
-
-        def returns_duplicates(
+        def return_dupes(
             product: str, pathways: list[list[str]]
         ) -> tuple[int, list[list[str]]]:
             return 200, [[SALICYLIC_ACID], [SALICYLIC_ACID]]
@@ -180,68 +170,66 @@ class TestFilterWithChecker:
             [[SALICYLIC_ACID], [SALICYLIC_ACID], [ACETIC_ACID]],
             ["first", "second", "third"],
             [0.1, 0.2, 0.3],
-            returns_duplicates,
+            return_dupes,
         )
 
         assert pathways == [[SALICYLIC_ACID], [SALICYLIC_ACID]]
         assert explanations == ["first", "second"]
         assert confidence == [0.1, 0.2]
 
-    def test_empty_pathways_short_circuits(self) -> None:
-        """Empty pathway list skips checker entirely."""
-        call_count = 0
-
-        def should_not_be_called(
-            product: str, pathways: list[list[str]]
-        ) -> tuple[int, list[list[str]]]:
-            nonlocal call_count
-            call_count += 1
-            return 200, pathways
-
+    def test_empty_pathways_returns_empty(self) -> None:
         pathways, explanations, confidence = filter_with_checker(
-            ASPIRIN, [], [], [], should_not_be_called
+            ASPIRIN, [], [], [], None
         )
-
-        assert pathways == []
-        assert call_count == 0
-
-    def test_unknown_pathway_from_checker_is_dropped(self) -> None:
-        """Checker returning a pathway not in the original input is silently dropped."""
-
-        def injects_unknown(
-            product: str, pathways: list[list[str]]
-        ) -> tuple[int, list[list[str]]]:
-            return 200, [[PARACETAMOL]]  # not in original input
-
-        pathways, explanations, confidence = filter_with_checker(
-            ASPIRIN,
-            [[SALICYLIC_ACID]],
-            ["hydrolysis"],
-            [0.9],
-            injects_unknown,
-        )
-
         assert pathways == []
         assert explanations == []
         assert confidence == []
 
+    def test_unknown_pathway_from_checker_raises(self) -> None:
+        """Checker returning a pathway absent from the original input is an error."""
 
-# ---------------------------------------------------------------------------
-# resolve_hallucination tests
-# ---------------------------------------------------------------------------
+        def inject_unknown(
+            product: str, pathways: list[list[str]]
+        ) -> tuple[int, list[list[str]]]:
+            return 200, [[PARACETAMOL]]
+
+        with pytest.raises(ValueError, match="not present in original input"):
+            filter_with_checker(
+                ASPIRIN, [[SALICYLIC_ACID]], ["hydrolysis"], [0.9], inject_unknown
+            )
+
+    def test_mismatched_lengths_raise(self) -> None:
+        """Pathways and metadata must have the same length."""
+        with pytest.raises(ValueError, match="same length"):
+            filter_with_checker(
+                ASPIRIN,
+                [[SALICYLIC_ACID], [ACETIC_ACID]],
+                ["only one"],
+                [0.1, 0.2],
+                None,
+            )
+
+    def test_shorter_confidence_raises(self) -> None:
+        with pytest.raises(ValueError, match="same length"):
+            filter_with_checker(
+                ASPIRIN,
+                [[SALICYLIC_ACID]],
+                ["explanation"],
+                [],
+                None,
+            )
 
 
 class TestResolveHallucination:
-    def test_none_mode_returns_none(self) -> None:
+    def test_none_mode(self) -> None:
         assert resolve_hallucination("none", None) is None
 
-    def test_heuristic_mode_returns_none(self) -> None:
+    def test_heuristic_mode(self) -> None:
         assert resolve_hallucination("heuristic", None) is None
 
-    def test_ml_mode_with_classifier_returns_callable(self) -> None:
-        classifier = _AlwaysCleanClassifier()
-        checker = resolve_hallucination("ml", classifier)
-        assert callable(checker)
+    def test_case_insensitive(self) -> None:
+        assert resolve_hallucination("NONE", None) is None
+        assert resolve_hallucination("Heuristic", None) is None
 
     def test_ml_mode_without_classifier_raises(self) -> None:
         with pytest.raises(ValueError, match="requires"):
@@ -251,13 +239,9 @@ class TestResolveHallucination:
         with pytest.raises(ValueError, match="hallucination_mode"):
             resolve_hallucination("unknown", None)
 
-    def test_case_insensitive(self) -> None:
-        assert resolve_hallucination("NONE", None) is None
-        assert resolve_hallucination("Heuristic", None) is None
-
-    def test_ml_checker_actually_filters(self) -> None:
-        """End-to-end: resolve → build → call with real molecules."""
-        classifier = _SelectiveClassifier(hallucinated_reactants={SALICYLIC_ACID})
+    def test_ml_mode_returns_working_checker(self) -> None:
+        """ML mode builds a checker that actually filters hallucinated pathways."""
+        classifier = SelectiveClassifier(hallucinated={SALICYLIC_ACID})
         checker = resolve_hallucination("ml", classifier)
         assert checker is not None
 

--- a/deepretro/tests/test_hallucination_helpers.py
+++ b/deepretro/tests/test_hallucination_helpers.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-from unittest.mock import call
 
 import pytest
 
@@ -13,128 +11,257 @@ from deepretro.models.hallucination_helpers import (
     resolve_hallucination,
 )
 
-
-def test_build_ml_checker_keeps_non_hallucinated_pathways(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """ML checker keeps pathways whose classifier prediction is clean."""
-    classifier = MagicMock()
-    classifier.predict_single.side_effect = [
-        {"is_hallucination": True},
-        {"is_hallucination": False},
-    ]
-    monkeypatch.setattr(
-        "deepretro.utils.utils_molecule.is_valid_smiles",
-        lambda smiles: True,
-    )
-
-    status, retained = build_ml_checker(classifier)("CCO", [["CC"], ["CO"]])
-
-    assert status == 200
-    assert retained == [["CO"]]
-    classifier.predict_single.assert_has_calls(
-        [
-            call("CCO", "CC"),
-            call("CCO", "CO"),
-        ]
-    )
+# Real molecule SMILES for meaningful tests
+ASPIRIN = "CC(=O)Oc1ccccc1C(=O)O"
+SALICYLIC_ACID = "OC(=O)c1ccccc1O"
+ACETIC_ACID = "CC(=O)O"
+PARACETAMOL = "CC(=O)Nc1ccc(O)cc1"
+PARA_AMINOPHENOL = "Nc1ccc(O)cc1"
 
 
-def test_build_ml_checker_drops_invalid_reactant_sets(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Invalid joined reactant SMILES are ignored before classifier calls."""
-    classifier = MagicMock()
-    monkeypatch.setattr(
-        "deepretro.utils.utils_molecule.is_valid_smiles",
-        lambda smiles: False,
-    )
-
-    status, retained = build_ml_checker(classifier)("CCO", [["not-valid"]])
-
-    assert status == 200
-    assert retained == []
-    classifier.predict_single.assert_not_called()
+# ---------------------------------------------------------------------------
+# Classifier test doubles — injected, not mocked
+# ---------------------------------------------------------------------------
 
 
-def test_filter_with_checker_preserves_explanation_and_confidence_alignment() -> None:
-    """Filtering retains metadata aligned to the surviving pathway."""
+class _AlwaysCleanClassifier:
+    """Classifier that marks every reaction as non-hallucinated."""
 
-    def checker(product: str, pathways: list[list[str]]) -> tuple[int, list[list[str]]]:
-        assert product == "CCO"
-        assert pathways == [["CC"], ["CO"]]
-        return 200, [["CO"]]
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
 
-    pathways, explanations, confidence = filter_with_checker(
-        "CCO",
-        [["CC"], ["CO"]],
-        ["first", "second"],
-        [0.1, 0.9],
-        checker,
-    )
-
-    assert pathways == [["CO"]]
-    assert explanations == ["second"]
-    assert confidence == [0.9]
+    def predict_single(self, product: str, reactants: str) -> dict[str, bool]:
+        self.calls.append((product, reactants))
+        return {"is_hallucination": False}
 
 
-def test_filter_with_checker_short_circuits_without_checker() -> None:
-    """No checker leaves pathways and metadata unchanged."""
-    pathways, explanations, confidence = filter_with_checker(
-        "CCO",
-        [["CC"], ["CO"]],
-        ["first", "second"],
-        [0.1, 0.9],
-        None,
-    )
+class _SelectiveClassifier:
+    """Classifier that marks specific reactants as hallucinated."""
 
-    assert pathways == [["CC"], ["CO"]]
-    assert explanations == ["first", "second"]
-    assert confidence == [0.1, 0.9]
+    def __init__(self, hallucinated_reactants: set[str]) -> None:
+        self.hallucinated = hallucinated_reactants
+        self.calls: list[tuple[str, str]] = []
+
+    def predict_single(self, product: str, reactants: str) -> dict[str, bool]:
+        self.calls.append((product, reactants))
+        return {"is_hallucination": reactants in self.hallucinated}
 
 
-def test_filter_with_checker_returns_empty_on_checker_failure() -> None:
-    """Non-200 checker status drops all aligned metadata."""
-
-    def checker(product: str, pathways: list[list[str]]) -> tuple[int, list[list[str]]]:
-        return 500, pathways
-
-    assert filter_with_checker("CCO", [["CC"]], ["first"], [0.1], checker) == (
-        [],
-        [],
-        [],
-    )
+# ---------------------------------------------------------------------------
+# build_ml_checker tests
+# ---------------------------------------------------------------------------
 
 
-def test_filter_with_checker_handles_duplicate_pathways_in_order() -> None:
-    """Duplicate retained pathways consume metadata entries one at a time."""
+class TestBuildMlChecker:
+    def test_keeps_non_hallucinated_aspirin_precursors(self) -> None:
+        """Both real precursors pass the classifier — both retained."""
+        classifier = _AlwaysCleanClassifier()
+        checker = build_ml_checker(classifier)
 
-    def checker(product: str, pathways: list[list[str]]) -> tuple[int, list[list[str]]]:
-        return 200, [["CC"], ["CC"]]
+        status, retained = checker(ASPIRIN, [[SALICYLIC_ACID], [ACETIC_ACID]])
 
-    pathways, explanations, confidence = filter_with_checker(
-        "CCO",
-        [["CC"], ["CC"], ["CO"]],
-        ["first", "second", "third"],
-        [0.1, 0.2, 0.3],
-        checker,
-    )
+        assert status == 200
+        assert retained == [[SALICYLIC_ACID], [ACETIC_ACID]]
+        assert len(classifier.calls) == 2
+        assert classifier.calls[0] == (ASPIRIN, SALICYLIC_ACID)
+        assert classifier.calls[1] == (ASPIRIN, ACETIC_ACID)
 
-    assert pathways == [["CC"], ["CC"]]
-    assert explanations == ["first", "second"]
-    assert confidence == [0.1, 0.2]
+    def test_filters_hallucinated_pathway(self) -> None:
+        """Classifier flags one precursor — only the clean one survives."""
+        classifier = _SelectiveClassifier(hallucinated_reactants={SALICYLIC_ACID})
+        checker = build_ml_checker(classifier)
+
+        status, retained = checker(ASPIRIN, [[SALICYLIC_ACID], [ACETIC_ACID]])
+
+        assert status == 200
+        assert retained == [[ACETIC_ACID]]
+
+    def test_drops_invalid_smiles_before_classifier(self) -> None:
+        """Invalid SMILES are filtered out before reaching the classifier."""
+        classifier = _AlwaysCleanClassifier()
+        checker = build_ml_checker(classifier)
+
+        status, retained = checker(ASPIRIN, [["not>>>valid"]])
+
+        assert status == 200
+        assert retained == []
+        assert classifier.calls == []
+
+    def test_missing_hallucination_key_defaults_to_filtered(self) -> None:
+        """Classifier returning no is_hallucination key treats pathway as hallucinated."""
+
+        class _NoKeyClassifier:
+            def predict_single(self, product: str, reactants: str) -> dict:
+                return {"confidence": 0.5}
+
+        checker = build_ml_checker(_NoKeyClassifier())
+        status, retained = checker(ASPIRIN, [[SALICYLIC_ACID]])
+
+        assert status == 200
+        assert retained == []
+
+    def test_multi_reactant_pathway_joins_with_dot(self) -> None:
+        """Multiple reactants in one pathway are joined with '.' for the classifier."""
+        classifier = _AlwaysCleanClassifier()
+        checker = build_ml_checker(classifier)
+
+        status, retained = checker(PARACETAMOL, [[PARA_AMINOPHENOL, ACETIC_ACID]])
+
+        assert status == 200
+        assert retained == [[PARA_AMINOPHENOL, ACETIC_ACID]]
+        expected_joined = f"{PARA_AMINOPHENOL}.{ACETIC_ACID}"
+        assert classifier.calls == [(PARACETAMOL, expected_joined)]
 
 
-def test_resolve_hallucination_modes() -> None:
-    """Mode resolution is explicit and validates ML classifier inputs."""
-    assert resolve_hallucination("none", None) is None
-    assert resolve_hallucination("heuristic", None) is None
+# ---------------------------------------------------------------------------
+# filter_with_checker tests
+# ---------------------------------------------------------------------------
 
-    classifier = MagicMock()
-    classifier.predict_single.return_value = {"is_hallucination": False}
-    assert callable(resolve_hallucination("ml", classifier))
 
-    with pytest.raises(ValueError, match="hallucination_mode"):
-        resolve_hallucination("unknown", None)
-    with pytest.raises(ValueError, match="requires"):
-        resolve_hallucination("ml", None)
+class TestFilterWithChecker:
+    def test_preserves_alignment_after_filtering(self) -> None:
+        """Retained pathway keeps its original explanation and confidence."""
+
+        def keeps_only_second(
+            product: str, pathways: list[list[str]]
+        ) -> tuple[int, list[list[str]]]:
+            return 200, [pathways[1]]
+
+        pathways, explanations, confidence = filter_with_checker(
+            ASPIRIN,
+            [[SALICYLIC_ACID], [ACETIC_ACID]],
+            ["hydrolysis", "deacetylation"],
+            [0.3, 0.9],
+            keeps_only_second,
+        )
+
+        assert pathways == [[ACETIC_ACID]]
+        assert explanations == ["deacetylation"]
+        assert confidence == [0.9]
+
+    def test_no_checker_passes_through(self) -> None:
+        """None checker returns everything unchanged."""
+        pathways, explanations, confidence = filter_with_checker(
+            ASPIRIN,
+            [[SALICYLIC_ACID], [ACETIC_ACID]],
+            ["first", "second"],
+            [0.1, 0.9],
+            None,
+        )
+
+        assert pathways == [[SALICYLIC_ACID], [ACETIC_ACID]]
+        assert explanations == ["first", "second"]
+        assert confidence == [0.1, 0.9]
+
+    def test_non_200_status_drops_everything(self) -> None:
+        """Non-200 checker status discards all pathways and metadata."""
+
+        def fails(
+            product: str, pathways: list[list[str]]
+        ) -> tuple[int, list[list[str]]]:
+            return 500, pathways
+
+        result = filter_with_checker(
+            ASPIRIN, [[SALICYLIC_ACID]], ["only"], [0.8], fails
+        )
+
+        assert result == ([], [], [])
+
+    def test_duplicate_pathways_consume_metadata_in_order(self) -> None:
+        """When checker returns duplicates, metadata is consumed sequentially."""
+
+        def returns_duplicates(
+            product: str, pathways: list[list[str]]
+        ) -> tuple[int, list[list[str]]]:
+            return 200, [[SALICYLIC_ACID], [SALICYLIC_ACID]]
+
+        pathways, explanations, confidence = filter_with_checker(
+            ASPIRIN,
+            [[SALICYLIC_ACID], [SALICYLIC_ACID], [ACETIC_ACID]],
+            ["first", "second", "third"],
+            [0.1, 0.2, 0.3],
+            returns_duplicates,
+        )
+
+        assert pathways == [[SALICYLIC_ACID], [SALICYLIC_ACID]]
+        assert explanations == ["first", "second"]
+        assert confidence == [0.1, 0.2]
+
+    def test_empty_pathways_short_circuits(self) -> None:
+        """Empty pathway list skips checker entirely."""
+        call_count = 0
+
+        def should_not_be_called(
+            product: str, pathways: list[list[str]]
+        ) -> tuple[int, list[list[str]]]:
+            nonlocal call_count
+            call_count += 1
+            return 200, pathways
+
+        pathways, explanations, confidence = filter_with_checker(
+            ASPIRIN, [], [], [], should_not_be_called
+        )
+
+        assert pathways == []
+        assert call_count == 0
+
+    def test_unknown_pathway_from_checker_is_dropped(self) -> None:
+        """Checker returning a pathway not in the original input is silently dropped."""
+
+        def injects_unknown(
+            product: str, pathways: list[list[str]]
+        ) -> tuple[int, list[list[str]]]:
+            return 200, [[PARACETAMOL]]  # not in original input
+
+        pathways, explanations, confidence = filter_with_checker(
+            ASPIRIN,
+            [[SALICYLIC_ACID]],
+            ["hydrolysis"],
+            [0.9],
+            injects_unknown,
+        )
+
+        assert pathways == []
+        assert explanations == []
+        assert confidence == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_hallucination tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveHallucination:
+    def test_none_mode_returns_none(self) -> None:
+        assert resolve_hallucination("none", None) is None
+
+    def test_heuristic_mode_returns_none(self) -> None:
+        assert resolve_hallucination("heuristic", None) is None
+
+    def test_ml_mode_with_classifier_returns_callable(self) -> None:
+        classifier = _AlwaysCleanClassifier()
+        checker = resolve_hallucination("ml", classifier)
+        assert callable(checker)
+
+    def test_ml_mode_without_classifier_raises(self) -> None:
+        with pytest.raises(ValueError, match="requires"):
+            resolve_hallucination("ml", None)
+
+    def test_unknown_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="hallucination_mode"):
+            resolve_hallucination("unknown", None)
+
+    def test_case_insensitive(self) -> None:
+        assert resolve_hallucination("NONE", None) is None
+        assert resolve_hallucination("Heuristic", None) is None
+
+    def test_ml_checker_actually_filters(self) -> None:
+        """End-to-end: resolve → build → call with real molecules."""
+        classifier = _SelectiveClassifier(hallucinated_reactants={SALICYLIC_ACID})
+        checker = resolve_hallucination("ml", classifier)
+        assert checker is not None
+
+        status, retained = checker(ASPIRIN, [[SALICYLIC_ACID], [ACETIC_ACID]])
+
+        assert status == 200
+        assert retained == [[ACETIC_ACID]]

--- a/deepretro/utils/typing.py
+++ b/deepretro/utils/typing.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any
 
 RouteNode = Mapping[str, Any]
 Step = dict[str, Any]
 DependencyMap = dict[str, list[str]]
 ParseOutput = dict[str, Any]
+HallucinationChecker = Callable[[str, list[list[str]]], tuple[int, list[list[str]]]]

--- a/deepretro/utils/utils_molecule.py
+++ b/deepretro/utils/utils_molecule.py
@@ -241,6 +241,32 @@ def calc_chemical_formula(mol: str) -> str:
     return CalcMolFormula(molecule)
 
 
+def canonicalize(smiles: str) -> str:
+    """Return canonical SMILES, or the original string if parsing fails.
+
+    Parameters
+    ----------
+    smiles : str
+        Input SMILES string.
+
+    Returns
+    -------
+    str
+        Canonical SMILES, or the original string when RDKit cannot parse it.
+
+    Examples
+    --------
+    >>> canonicalize("C(O)C")
+    'CCO'
+    >>> canonicalize("not_a_smiles")
+    'not_a_smiles'
+    """
+    molecule = Chem.MolFromSmiles(smiles)
+    if molecule is None:
+        return smiles
+    return Chem.MolToSmiles(molecule, canonical=True)
+
+
 def are_molecules_same(smiles1: str, smiles2: str) -> bool:
     """Check whether two SMILES strings describe the same molecule.
 

--- a/docs/source/package/deepretro.utils_pkg.rst
+++ b/docs/source/package/deepretro.utils_pkg.rst
@@ -47,7 +47,6 @@ Behavior highlights:
 
 - Auto-bypass for trivial/basic molecules via ``BASIC_MOLECULES`` and
   ``is_basic_molecule``.
-- Caching via ``src.cache.cache_results`` decorator.
 - Explicit process-local caching helpers live in ``deepretro.utils.cache`` when
   callers need in-memory caching without shared global state.
 - Returns route dictionaries with metadata and scores from AiZynthFinder.


### PR DESCRIPTION
## Summary
- Add `hallucination_helpers` module with ML/heuristic pathway filtering (`build_ml_checker`, `filter_with_checker`, `resolve_hallucination`)
- Add `HallucinationChecker` type alias to `deepretro.utils.typing`
- Add `canonicalize()` to `utils_molecule` for canonical SMILES normalization
- Full test suite for hallucination helpers (7 tests)
- Update `models/__init__` exports

The checker now takes an already-loaded classifier **object** (anything satisfying `HallucinationPredictor`) instead of loading a model from a path string. This decouples the helpers from deepchem/`HallucinationClassifier`, makes them trivially testable with fakes, and lets callers control model lifetime. Path-based loading was intentionally removed.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings