### PR TITLE
Agentic tool-calling retrosynthesis in deepretro (AutoSolver + agents + batch runner)

### DIFF
--- a/deepretro/__init__.py
+++ b/deepretro/__init__.py
@@ -5,10 +5,19 @@ Provides DeepChem-compatible featurizers, dataset loaders, algorithms,
 and model wrappers for reaction-step data.
 """
 
-__all__ = ["ReactionStepFeaturizer", "configure_logging", "HallucinationClassifier"]
+__all__ = [
+    "ReactionStepFeaturizer",
+    "configure_logging",
+    "HallucinationClassifier",
+    "AutoSolver",
+]
 
 
 def __getattr__(name: str):
+    if name == "AutoSolver":
+        from deepretro.algorithms.autosolve import AutoSolver
+
+        return AutoSolver
     if name == "ReactionStepFeaturizer":
         from deepretro.featurizers.reactionstep import ReactionStepFeaturizer
 

--- a/deepretro/agents/__init__.py
+++ b/deepretro/agents/__init__.py
@@ -1,0 +1,35 @@
+"""Agentic tool-calling layer for DeepRetro retrosynthesis.
+
+Exposes the code-execution sandbox, the tool registry, and the single-step
+agent loop used by :class:`deepretro.algorithms.autosolve.AutoSolver` when
+``solve_mode="single_step_agent"``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "SandboxResult",
+    "SubprocessSandbox",
+    "build_tool_registry",
+    "agentic_single_step",
+    "agentic_orchestrator",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve agent exports (PEP 562) to keep imports light."""
+    if name in ("SandboxResult", "SubprocessSandbox"):
+        from deepretro.agents import sandbox
+
+        return getattr(sandbox, name)
+    if name == "build_tool_registry":
+        from deepretro.agents.tools import build_tool_registry
+
+        return build_tool_registry
+    if name in ("agentic_single_step", "agentic_orchestrator"):
+        from deepretro.agents import loop
+
+        return getattr(loop, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/deepretro/agents/loop.py
+++ b/deepretro/agents/loop.py
@@ -1,0 +1,218 @@
+"""Single-step tool-calling agent loop for retrosynthesis.
+
+``agentic_single_step`` replaces the non-agentic ``llm_pipeline`` when
+``AutoSolver`` runs with ``solve_mode="single_step_agent"``. The model may call
+tools (validity / stability / hallucination / ``run_python``) to self-check its
+proposed precursors, then emits the same tagged-JSON payload the pipeline
+expects. The result is returned in ``llm_pipeline``'s ``(pathways, explanations,
+confidence)`` shape and is *still* run through the deterministic safety filters
+in :meth:`AutoSolver.run_llm`.
+
+The model call is injectable (``llm_runner``) so the loop is unit-tested with no
+network. The default runner calls ``litellm.completion`` with the tool schemas
+and normalizes the returned message to an OpenAI-format assistant dict.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import structlog
+
+from deepretro.agents.tools import build_tool_registry
+from deepretro.utils.llm_helpers import Pathway
+
+logger = structlog.get_logger(__name__)
+
+ModelCall = Callable[[list[dict[str, Any]]], dict[str, Any]]
+
+_TOOL_INSTRUCTION = (
+    "\n\nYou may call the provided tools to validate SMILES, check stability, "
+    "check for hallucinations, or run Python for any calculation before you "
+    "commit to an answer. When you are done, respond with the final answer in "
+    "exactly the JSON format described above (do not call a tool in that final "
+    "message)."
+)
+
+
+def agentic_single_step(
+    molecule: str,
+    model: str,
+    *,
+    tool_backend: str = "structured",
+    sandbox: Any | None = None,
+    hallucination_checker: Any | None = None,
+    max_iterations: int = 6,
+    llm_runner: ModelCall | None = None,
+    enable_thinking: bool = False,
+    max_output_tokens: int | None = None,
+) -> tuple[list[Pathway], list[str], list[float]]:
+    """Propose precursors for one molecule via a tool-calling agent.
+
+    Parameters
+    ----------
+    molecule : str
+        Target molecule SMILES.
+    model : str
+        LiteLLM model identifier.
+    tool_backend : {"structured", "sandbox"}, optional
+        Which tools to expose. ``sandbox`` adds ``run_python``.
+    sandbox : Sandbox or None, optional
+        Sandbox for ``run_python`` (a default is created if needed).
+    hallucination_checker : callable or None, optional
+        Resolved checker exposed as the ``check_hallucination`` tool.
+    max_iterations : int, optional
+        Maximum model turns before giving up.
+    llm_runner : callable, optional
+        Injectable model call ``(messages) -> assistant_message_dict``. When
+        ``None``, ``litellm.completion`` is used.
+    enable_thinking : bool, optional
+        Reasoning controls. Defaults to ``False``: multi-turn tool use with
+        extended thinking is rejected by Anthropic unless the signed thinking
+        block is preserved.
+    max_output_tokens : int, optional
+        Output-token override for the model call.
+
+    Returns
+    -------
+    tuple[list[Pathway], list[str], list[float]]
+        Pathways, explanations, and confidence scores. Empty lists when the
+        agent produces no parseable final answer within ``max_iterations``.
+
+    Examples
+    --------
+    >>> final = {
+    ...     "role": "assistant",
+    ...     "content": '<json>{"data": [["CCO"]], "explanation": ["reduce"], '
+    ...     '"confidence_scores": [0.8]}</json>',
+    ... }
+    >>> agentic_single_step("CC=O", "openai/gpt-4o-mini", llm_runner=lambda m: final)
+    ([['CCO']], ['reduce'], [0.8])
+    """
+    registry = build_tool_registry(hallucination_checker, sandbox, tool_backend)
+    messages = _build_initial_messages(molecule, model)
+    call_model = llm_runner or _make_default_model_call(
+        model, registry.schemas, enable_thinking, max_output_tokens
+    )
+
+    for _iteration in range(max_iterations):
+        assistant = call_model(messages)
+        messages.append(assistant)
+
+        tool_calls = assistant.get("tool_calls")
+        if not tool_calls:
+            return _parse_final_answer(assistant.get("content") or "", model)
+
+        for tool_call in tool_calls:
+            function = tool_call.get("function", {})
+            name = function.get("name", "")
+            arguments = _parse_arguments(function.get("arguments"))
+            result = registry.execute(name, arguments)
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call.get("id", ""),
+                    "content": json.dumps(result),
+                }
+            )
+
+    logger.warning(
+        "Agent reached max_iterations without a final answer",
+        molecule=molecule,
+        max_iterations=max_iterations,
+    )
+    return [], [], []
+
+
+def agentic_orchestrator(
+    molecule: str,
+    model: str,
+    **kwargs: Any,
+) -> tuple[list[Pathway], list[str], list[float]]:
+    """Top-level tool-driven search over the whole tree (not implemented).
+
+    The interface and flag wiring exist; ``single_step_agent`` is the built-out
+    agent mode. This scaffold raises so the reserved mode fails loudly.
+
+    Raises
+    ------
+    NotImplementedError
+        Always.
+
+    Examples
+    --------
+    >>> agentic_orchestrator("CCO", "openai/gpt-4o-mini")
+    Traceback (most recent call last):
+    NotImplementedError: agentic_orchestrator is not implemented yet
+    """
+    raise NotImplementedError("agentic_orchestrator is not implemented yet")
+
+
+def _build_initial_messages(molecule: str, model: str) -> list[dict[str, Any]]:
+    """Build the [system, user] messages with tool-usage guidance appended."""
+    from deepretro.utils.llm import build_messages
+
+    messages = [dict(message) for message in build_messages(molecule, model)]
+    if messages and messages[0].get("role") == "system":
+        messages[0]["content"] = f"{messages[0].get('content', '')}{_TOOL_INSTRUCTION}"
+    return messages
+
+
+def _parse_arguments(arguments: Any) -> dict[str, Any]:
+    """Parse tool-call arguments (a JSON string or already a dict)."""
+    if isinstance(arguments, dict):
+        return arguments
+    if not arguments:
+        return {}
+    try:
+        parsed = json.loads(arguments)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _parse_final_answer(
+    content: str,
+    model: str,
+) -> tuple[list[Pathway], list[str], list[float]]:
+    """Parse a final assistant message into pathways/explanations/confidence."""
+    from deepretro.utils.llm import parse_response, validate_split_json
+
+    status, _thinking, json_content = parse_response(content, model)
+    if status != 200 or not json_content:
+        return [], [], []
+    status, pathways, explanations, confidence = validate_split_json(json_content)
+    if status != 200:
+        return [], [], []
+    return pathways, explanations, confidence
+
+
+def _make_default_model_call(
+    model: str,
+    tools: list[dict[str, Any]],
+    enable_thinking: bool,
+    max_output_tokens: int | None,
+) -> ModelCall:
+    """Build the default ``litellm.completion``-backed model call."""
+
+    def _call(messages: list[dict[str, Any]]) -> dict[str, Any]:
+        from litellm import completion
+
+        from deepretro.utils.llm_helpers import build_completion_params
+
+        params = build_completion_params(
+            model=model,
+            messages=messages,
+            max_completion_tokens=max_output_tokens or 8192,
+            temperature=0.0,
+            enable_thinking=enable_thinking,
+            metadata={"task": "retrosynthesis_agent"},
+        )
+        params["tools"] = tools
+        response = completion(**params)
+        message = response.choices[0].message
+        return message.model_dump()
+
+    return _call

--- a/deepretro/agents/loop.py
+++ b/deepretro/agents/loop.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import structlog
 
 from deepretro.agents.tools import build_tool_registry
-from deepretro.utils.llm_helpers import Pathway
+from deepretro.utils.llm_helpers import ChatMessage, Pathway
 
 logger = structlog.get_logger(__name__)
 
@@ -204,7 +204,9 @@ def _make_default_model_call(
 
         params = build_completion_params(
             model=model,
-            messages=messages,
+            # The conversation is an OpenAI-format superset of ChatMessage
+            # (assistant tool-call turns, tool results); litellm accepts it.
+            messages=cast("list[ChatMessage]", messages),
             max_completion_tokens=max_output_tokens or 8192,
             temperature=0.0,
             enable_thinking=enable_thinking,

--- a/deepretro/agents/sandbox.py
+++ b/deepretro/agents/sandbox.py
@@ -1,0 +1,238 @@
+"""Hardened subprocess sandbox for agent-generated Python code.
+
+The agent's ``run_python`` tool executes model-written code. That code is
+*semi-trusted* (produced by the LLM's own reasoning, never interpolated from
+untrusted Google-Sheet / molecule-file text), so the sandbox aims to make the
+common failure modes safe rather than to be an escape-proof jail:
+
+* **Secret scrubbing (primary guarantee).** The child runs with a minimal
+  allow-list environment, so API keys in the parent process (``ANTHROPIC_API_KEY``
+  and friends) can never be read or exfiltrated by generated code.
+* **Resource caps.** POSIX ``RLIMIT_AS`` / ``RLIMIT_CPU`` / ``RLIMIT_NPROC`` /
+  ``RLIMIT_FSIZE`` bound memory, CPU, fork-bombs, and file writes.
+* **Wall-clock timeout.** The child process group is killed on expiry.
+* **Best-effort network isolation.** On Linux with ``unshare`` available the
+  child runs in a fresh, network-less namespace.
+
+ponytail: subprocess + rlimits + secret-scrub is adequate for semi-trusted
+code; it is NOT namespace isolation on macOS (``RLIMIT_AS`` unenforced, no
+``unshare``). Upgrade path: a ``PodmanSandbox`` (``--network=none``, read-only
+rootfs) implementing the same :class:`Sandbox` protocol.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Environment variables the child is allowed to inherit. Everything else
+# (notably provider API keys) is dropped.
+_ENV_ALLOWLIST = ("PATH", "LANG", "LC_ALL", "LC_CTYPE", "HOME", "TMPDIR", "SYSTEMROOT")
+
+# Floor for the address-space limit so RDKit/deepretro imports do not
+# MemoryError on start-up regardless of a small requested ``mem_mb``.
+_MIN_ADDRESS_SPACE_MB = 1024
+
+
+@dataclass(frozen=True)
+class SandboxResult:
+    """Outcome of one sandboxed execution.
+
+    Attributes
+    ----------
+    ok : bool
+        ``True`` when the code exited with status 0 within limits.
+    stdout : str
+        Captured standard output.
+    stderr : str
+        Captured standard error (traceback on failure).
+    error : str
+        Sandbox-level error (e.g. a timeout message); empty on success.
+
+    Examples
+    --------
+    >>> SandboxResult(ok=True, stdout="hi\\n", stderr="", error="").ok
+    True
+    """
+
+    ok: bool
+    stdout: str
+    stderr: str
+    error: str
+
+
+@runtime_checkable
+class Sandbox(Protocol):
+    """Protocol for code-execution backends used by the ``run_python`` tool."""
+
+    def run(
+        self, code: str, *, timeout_s: float = ..., mem_mb: int = ...
+    ) -> SandboxResult:
+        """Execute *code* and return a :class:`SandboxResult`."""
+        ...
+
+
+def _build_child_env() -> dict[str, str]:
+    """Return a minimal environment with provider secrets removed.
+
+    Returns
+    -------
+    dict[str, str]
+        Only the allow-listed variables from the parent environment.
+
+    Examples
+    --------
+    >>> "ANTHROPIC_API_KEY" in _build_child_env()
+    False
+    """
+    env = {key: os.environ[key] for key in _ENV_ALLOWLIST if key in os.environ}
+    # Force unbuffered output so captured stdout is complete even on kill.
+    env["PYTHONUNBUFFERED"] = "1"
+    return env
+
+
+def _apply_limits(mem_mb: int, cpu_seconds: int) -> None:
+    """Start a new session and apply POSIX resource limits (best effort).
+
+    Runs in the child via ``preexec_fn``. Each limit is guarded because some
+    are unsupported or unenforced on certain platforms (e.g. macOS).
+    """
+    import resource
+
+    os.setsid()
+    mem_bytes = max(mem_mb, _MIN_ADDRESS_SPACE_MB) * 1024 * 1024
+    limits = [
+        (resource.RLIMIT_AS, mem_bytes),
+        (resource.RLIMIT_CPU, cpu_seconds),
+        (resource.RLIMIT_FSIZE, 64 * 1024 * 1024),
+    ]
+    if hasattr(resource, "RLIMIT_NPROC"):
+        limits.append((resource.RLIMIT_NPROC, 64))
+    for res, limit in limits:
+        try:
+            resource.setrlimit(res, (limit, limit))
+        except (ValueError, OSError):  # pragma: no cover - platform dependent
+            pass
+
+
+class SubprocessSandbox:
+    """Run Python code in a resource-limited, secret-scrubbed subprocess.
+
+    Parameters
+    ----------
+    python_executable : str, optional
+        Interpreter used for the child. Defaults to the current interpreter,
+        so installed packages (RDKit, deepretro) remain importable.
+    allow_network : bool, optional
+        When ``False`` (default), the child is run under ``unshare -rn`` if
+        available (Linux) to remove network access.
+
+    Examples
+    --------
+    >>> SubprocessSandbox().run("print(2 + 2)").stdout.strip()
+    '4'
+    """
+
+    def __init__(
+        self,
+        python_executable: str | None = None,
+        *,
+        allow_network: bool = False,
+    ) -> None:
+        """Store the interpreter path and network policy."""
+        self.python_executable = python_executable or sys.executable
+        self.allow_network = allow_network
+
+    def _command(self, script_path: str) -> list[str]:
+        """Build the argv, prefixing an unshare wrapper when isolating network."""
+        base = [self.python_executable, "-I", script_path]
+        if self.allow_network:
+            return base
+        unshare = shutil.which("unshare")
+        if unshare is not None and sys.platform.startswith("linux"):
+            return [unshare, "-rn", *base]
+        return base
+
+    def run(
+        self,
+        code: str,
+        *,
+        timeout_s: float = 10.0,
+        mem_mb: int = 2048,
+    ) -> SandboxResult:
+        """Execute *code* and capture its output.
+
+        Parameters
+        ----------
+        code : str
+            Python source to execute.
+        timeout_s : float, optional
+            Wall-clock timeout in seconds.
+        mem_mb : int, optional
+            Address-space limit in MiB (floored at 1024).
+
+        Returns
+        -------
+        SandboxResult
+            Execution outcome.
+
+        Examples
+        --------
+        >>> SubprocessSandbox().run("print('ok')").ok
+        True
+        """
+        cpu_seconds = max(1, int(timeout_s) + 1)
+        preexec = (
+            (lambda: _apply_limits(mem_mb, cpu_seconds)) if os.name == "posix" else None
+        )
+        with tempfile.TemporaryDirectory(prefix="deepretro_sandbox_") as workdir:
+            script_path = os.path.join(workdir, "snippet.py")
+            with open(script_path, "w", encoding="utf-8") as handle:
+                handle.write(code)
+
+            try:
+                proc = subprocess.Popen(
+                    self._command(script_path),
+                    cwd=workdir,
+                    env=_build_child_env(),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    preexec_fn=preexec,
+                )
+            except OSError as exc:  # pragma: no cover - spawn failure
+                logger.error("Sandbox failed to start", error=str(exc))
+                return SandboxResult(False, "", "", f"failed to start sandbox: {exc}")
+
+            try:
+                stdout, stderr = proc.communicate(timeout=timeout_s)
+            except subprocess.TimeoutExpired:
+                _kill_process_group(proc.pid)
+                stdout, stderr = proc.communicate()
+                return SandboxResult(
+                    False,
+                    stdout or "",
+                    stderr or "",
+                    f"execution timed out after {timeout_s}s",
+                )
+
+            ok = proc.returncode == 0
+            error = "" if ok else f"exited with status {proc.returncode}"
+            return SandboxResult(ok, stdout or "", stderr or "", error)
+
+
+def _kill_process_group(pid: int) -> None:
+    """Kill the child's process group so no orphaned children survive."""
+    try:
+        os.killpg(os.getpgid(pid), 9)
+    except (ProcessLookupError, PermissionError, OSError):  # pragma: no cover
+        pass

--- a/deepretro/agents/tools.py
+++ b/deepretro/agents/tools.py
@@ -1,0 +1,283 @@
+"""Tool registry, executors, and dispatcher for the retrosynthesis agent.
+
+Schemas use the OpenAI function-calling format
+(``{"type": "function", "function": {...}}``) because LiteLLM normalizes every
+provider (including Anthropic) to that shape. :func:`build_tool_registry`
+assembles the tools appropriate for a ``tool_backend`` and binds
+``check_hallucination`` to a resolved checker so the ML classifier can be
+swapped in without touching tool code.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from deepretro.algorithms.stability_checker import check_molecule_stability
+from deepretro.utils.typing import HallucinationChecker
+from deepretro.utils.utils_molecule import canonicalize, is_valid_smiles
+
+logger = structlog.get_logger(__name__)
+
+ToolExecutor = Callable[..., dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class ToolRegistry:
+    """Bundle of LiteLLM tool schemas and their executors.
+
+    Attributes
+    ----------
+    schemas : list[dict]
+        OpenAI function-format tool definitions to pass to ``completion``.
+    executors : dict[str, ToolExecutor]
+        Mapping from tool name to its executor callable.
+
+    Examples
+    --------
+    >>> registry = build_tool_registry()
+    >>> registry.execute("validate_smiles", {"smiles": "C(O)C"})["canonical_smiles"]
+    'CCO'
+    """
+
+    schemas: list[dict[str, Any]]
+    executors: dict[str, ToolExecutor]
+
+    @property
+    def names(self) -> list[str]:
+        """Return the registered tool names."""
+        return list(self.executors)
+
+    def execute(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Dispatch a tool call, capturing unknown-tool and executor errors.
+
+        Parameters
+        ----------
+        name : str
+            Tool name from the model's tool call.
+        arguments : dict
+            Parsed tool-call arguments.
+
+        Returns
+        -------
+        dict
+            The tool result, or ``{"error": ...}`` on an unknown tool or an
+            executor exception.
+
+        Examples
+        --------
+        >>> build_tool_registry().execute("nope", {})["error"]
+        'unknown tool: nope'
+        """
+        executor = self.executors.get(name)
+        if executor is None:
+            return {"error": f"unknown tool: {name}"}
+        try:
+            return executor(**arguments)
+        except Exception as exc:  # ponytail: model-supplied args; never crash the loop
+            logger.warning("Tool execution failed", tool=name, error=str(exc))
+            return {"error": f"tool {name} failed: {exc}"}
+
+
+def _validate_smiles(smiles: str, context: str | None = None) -> dict[str, Any]:
+    """Validate a SMILES string and return its canonical form."""
+    if not is_valid_smiles(smiles):
+        return {
+            "valid": False,
+            "canonical_smiles": None,
+            "error": "invalid SMILES string — cannot be parsed by RDKit",
+            "context": context or "",
+        }
+    return {
+        "valid": True,
+        "canonical_smiles": canonicalize(smiles),
+        "error": None,
+        "context": context or "",
+    }
+
+
+def _check_stability(smiles: str) -> dict[str, Any]:
+    """Assess heuristic molecular stability for a SMILES string."""
+    report = check_molecule_stability(smiles)
+    return {
+        "assessment": report.get("assessment"),
+        "stability_score": report.get("stability_score"),
+        "issues": report.get("issues", []),
+    }
+
+
+def _make_check_hallucination(checker: HallucinationChecker) -> ToolExecutor:
+    """Bind a resolved hallucination checker into a tool executor.
+
+    TEMPLATE seam: the executor delegates entirely to *checker*. In heuristic
+    mode this is the working package heuristic; the ML wiring is completed by
+    a downstream contributor by passing a trained-classifier checker.
+    """
+
+    def _check(product: str, reactants: str | list[str]) -> dict[str, Any]:
+        pathway = reactants if isinstance(reactants, list) else [reactants]
+        status, kept = checker(product, [pathway])
+        is_hallucination = status != 200 or not kept
+        return {
+            "is_hallucination": is_hallucination,
+            "note": (
+                "kept by checker" if not is_hallucination else "flagged by checker"
+            ),
+        }
+
+    return _check
+
+
+def _make_run_python(sandbox: Any) -> ToolExecutor:
+    """Bind a sandbox into a ``run_python`` tool executor."""
+
+    def _run(code: str) -> dict[str, Any]:
+        result = sandbox.run(code)
+        return {
+            "ok": result.ok,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "error": result.error,
+        }
+
+    return _run
+
+
+_VALIDATE_SMILES_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "validate_smiles",
+        "description": (
+            "Validate a SMILES string and return its canonical form. Call this "
+            "before proposing any precursor to ensure it is chemically valid."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "smiles": {"type": "string", "description": "SMILES to validate"},
+                "context": {
+                    "type": "string",
+                    "description": "Optional note, e.g. 'reactant 1'",
+                },
+            },
+            "required": ["smiles"],
+        },
+    },
+}
+
+_CHECK_STABILITY_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "check_stability",
+        "description": (
+            "Assess whether a molecule is chemically stable using heuristic "
+            "structural checks. Returns an assessment and a 0-100 score."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "smiles": {"type": "string", "description": "SMILES to assess"},
+            },
+            "required": ["smiles"],
+        },
+    },
+}
+
+_CHECK_HALLUCINATION_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "check_hallucination",
+        "description": (
+            "Check whether a proposed retrosynthesis step is a likely "
+            "hallucination given the product and its reactants."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "product": {"type": "string", "description": "Product SMILES"},
+                "reactants": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Reactant SMILES for the proposed step",
+                },
+            },
+            "required": ["product", "reactants"],
+        },
+    },
+}
+
+_RUN_PYTHON_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "run_python",
+        "description": (
+            "Execute Python in a sandbox to compute chemistry (RDKit and the "
+            "deepretro package are importable). Print results to stdout. No "
+            "network access and a short time/memory budget."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "code": {"type": "string", "description": "Python source to run"},
+            },
+            "required": ["code"],
+        },
+    },
+}
+
+
+def build_tool_registry(
+    hallucination_checker: HallucinationChecker | None = None,
+    sandbox: Any | None = None,
+    tool_backend: str = "structured",
+) -> ToolRegistry:
+    """Assemble the tool registry for a given backend.
+
+    Parameters
+    ----------
+    hallucination_checker : callable or None, optional
+        Resolved checker ``(product, pathways) -> (status, kept)``. When
+        ``None`` the ``check_hallucination`` tool is omitted.
+    sandbox : Sandbox or None, optional
+        Sandbox for ``run_python``. A default :class:`SubprocessSandbox` is
+        created when needed and none is supplied.
+    tool_backend : {"structured", "sandbox"}, optional
+        ``structured`` exposes the read-only check tools. ``sandbox`` adds the
+        ``run_python`` code-execution tool.
+
+    Returns
+    -------
+    ToolRegistry
+        Schemas and executors for the selected backend.
+
+    Examples
+    --------
+    >>> "run_python" in build_tool_registry(tool_backend="sandbox").names
+    True
+    >>> "run_python" in build_tool_registry(tool_backend="structured").names
+    False
+    """
+    schemas: list[dict[str, Any]] = [_VALIDATE_SMILES_SCHEMA, _CHECK_STABILITY_SCHEMA]
+    executors: dict[str, ToolExecutor] = {
+        "validate_smiles": _validate_smiles,
+        "check_stability": _check_stability,
+    }
+
+    if hallucination_checker is not None:
+        schemas.append(_CHECK_HALLUCINATION_SCHEMA)
+        executors["check_hallucination"] = _make_check_hallucination(
+            hallucination_checker
+        )
+
+    if tool_backend == "sandbox":
+        if sandbox is None:
+            from deepretro.agents.sandbox import SubprocessSandbox
+
+            sandbox = SubprocessSandbox()
+        schemas.append(_RUN_PYTHON_SCHEMA)
+        executors["run_python"] = _make_run_python(sandbox)
+
+    return ToolRegistry(schemas=schemas, executors=executors)

--- a/deepretro/algorithms/__init__.py
+++ b/deepretro/algorithms/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from .hallucination_checker import (
     calculate_hallucination_score,
     hallucination_compare_molecules,
@@ -13,6 +15,7 @@ from .stability_checker import (
 )
 
 __all__ = [
+    "AutoSolver",
     "calculate_hallucination_score",
     "hallucination_compare_molecules",
     "interpret_score",
@@ -22,3 +25,33 @@ __all__ = [
     "check_carbenes",
     "check_fused_cyclopentane",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve :class:`AutoSolver` (PEP 562 module hook).
+
+    ``AutoSolver`` lives in :mod:`deepretro.algorithms.autosolve`, which pulls
+    in heavier retrosynthesis dependencies. Loading it lazily keeps
+    ``import deepretro.algorithms`` cheap for callers that only need the
+    lightweight checker helpers.
+
+    Parameters
+    ----------
+    name : str
+        Attribute name requested on the module.
+
+    Returns
+    -------
+    Any
+        The resolved attribute.
+
+    Raises
+    ------
+    AttributeError
+        If *name* is not a lazily exported attribute.
+    """
+    if name == "AutoSolver":
+        from deepretro.algorithms.autosolve import AutoSolver
+
+        return AutoSolver
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/deepretro/algorithms/autosolve.py
+++ b/deepretro/algorithms/autosolve.py
@@ -1,0 +1,836 @@
+"""Automatic single-molecule retrosynthesis solver.
+
+Ports the recursive AiZynthFinder + LLM retrosynthesis loop into the
+``deepretro`` package. AZ is tried first at every node; when it cannot solve a
+molecule the LLM (or, under ``solve_mode="single_step_agent"``, a tool-calling
+agent) proposes precursors, which are recursively solved until AZ solves each
+leaf. ``run_llm`` is the single owner of validity, stability, and hallucination
+filtering, so the agent path can never bypass the safety checks.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable, Sequence
+from typing import Any, Optional
+
+import structlog
+
+from deepretro.metadata_types import (
+    ConditionsRecommender,
+    LiteratureRecommender,
+    ReagentRecommender,
+)
+from deepretro.models.hallucination_helpers import (
+    filter_with_checker,
+    resolve_hallucination,
+)
+from deepretro.utils.az import run_az
+from deepretro.utils.llm_helpers import Pathway
+from deepretro.utils.parse import format_output
+from deepretro.utils.typing import HallucinationChecker, ParseOutput, RouteNode
+from deepretro.utils.utils_molecule import canonicalize, validity_check
+
+logger = structlog.get_logger(__name__)
+
+VALID_SOLVE_MODES = ("pipeline", "single_step_agent", "orchestrator")
+VALID_TOOL_BACKENDS = ("structured", "sandbox")
+
+
+class AutoSolver:
+    """Solve a target molecule with AiZynthFinder and an LLM fallback.
+
+    Parameters
+    ----------
+    llm : str, optional
+        LiteLLM model identifier used by the fallback retrosynthesis pipeline.
+    az_model : str, optional
+        AiZynthFinder model variant.
+    stability_check : bool, optional
+        Whether LLM candidates should pass the heuristic stability filter.
+    hallucination_mode : {"heuristic", "ml", "none"}, optional
+        Hallucination filter strategy. ``heuristic`` and ``ml`` both resolve to
+        a checker that runs inside :meth:`run_llm`; ``none`` disables filtering.
+    hallucination_classifier : object or str or Path or None, optional
+        For ``hallucination_mode="ml"``, either a loaded classifier exposing
+        ``predict_probability``/``threshold``/``featurizer`` or a path to a
+        saved model directory. Ignored for the other modes.
+    solve_mode : {"pipeline", "single_step_agent", "orchestrator"}, optional
+        ``pipeline`` (default) uses the non-agentic LLM pipeline. ``single_step_agent``
+        lets a tool-calling agent propose and self-check precursors. ``orchestrator``
+        is reserved and raises :class:`NotImplementedError` when invoked.
+    tool_backend : {"structured", "sandbox"}, optional
+        Which tools the agent may call. Ignored when ``solve_mode="pipeline"``.
+    sandbox : Sandbox or None, optional
+        Sandbox used by the agent's ``run_python`` tool. Injectable for testing.
+    max_depth : int, optional
+        Maximum retrosynthesis recursion depth.
+    enable_thinking : bool, optional
+        Whether provider-supported reasoning controls should be enabled.
+    max_output_tokens : int, optional
+        Output-token override for LLM calls.
+    metadata_model : str, optional
+        Model identifier used for metadata recommendation steps.
+    az_runner : callable, optional
+        Replacement for the default AiZynthFinder call. Accepts
+        ``(smiles, az_model)`` and returns ``(solved, routes)``.
+    llm_runner : callable, optional
+        Replacement for the default LLM pipeline call (``pipeline`` mode).
+    agent_runner : callable, optional
+        Replacement for the default tool-calling agent (``single_step_agent`` mode).
+        Accepts ``(molecule, **kwargs)`` and returns ``(pathways, explanations,
+        confidence)``.
+
+    Raises
+    ------
+    ValueError
+        If ``max_depth`` is negative, ``solve_mode``/``tool_backend`` is
+        unknown, or ``hallucination_mode`` is ``"ml"`` without a classifier.
+
+    Examples
+    --------
+    >>> solver = AutoSolver(
+    ...     az_runner=lambda s, m: (False, []),
+    ...     llm_runner=lambda mol, **kw: ([], [], []),
+    ...     hallucination_mode="none",
+    ... )
+    >>> solver.max_depth
+    50
+    """
+
+    def __init__(
+        self,
+        llm: str = "anthropic/claude-sonnet-4-6",
+        az_model: str = "Pistachio_100+",
+        stability_check: bool = True,
+        hallucination_mode: str = "heuristic",
+        hallucination_classifier: Any | None = None,
+        solve_mode: str = "pipeline",
+        tool_backend: str = "structured",
+        sandbox: Any | None = None,
+        max_depth: int = 50,
+        enable_thinking: bool = True,
+        max_output_tokens: int | None = None,
+        metadata_model: str = "anthropic/claude-sonnet-4-6",
+        az_runner: Callable[..., tuple[bool, list[Any]]] | None = None,
+        llm_runner: Callable[..., tuple[list[Any], list[str], list[float]]]
+        | None = None,
+        agent_runner: Callable[..., tuple[list[Any], list[str], list[float]]]
+        | None = None,
+    ) -> None:
+        """Construct an AutoSolver; see the class docstring for parameters."""
+        if max_depth < 0:
+            raise ValueError("max_depth must be non-negative")
+
+        solve_mode = solve_mode.lower()
+        if solve_mode not in VALID_SOLVE_MODES:
+            raise ValueError(
+                f"solve_mode must be one of {VALID_SOLVE_MODES} — got {solve_mode!r}"
+            )
+        tool_backend = tool_backend.lower()
+        if tool_backend not in VALID_TOOL_BACKENDS:
+            raise ValueError(
+                f"tool_backend must be one of {VALID_TOOL_BACKENDS} "
+                f"— got {tool_backend!r}"
+            )
+
+        self.llm = llm
+        self.az_model = az_model
+        self.stability_check = stability_check
+        self.hallucination_mode = hallucination_mode.lower()
+        self.hallucination_checker: Optional[HallucinationChecker] = (
+            resolve_hallucination(self.hallucination_mode, hallucination_classifier)
+        )
+        self.solve_mode = solve_mode
+        self.tool_backend = tool_backend
+        self.sandbox = sandbox
+        self.max_depth = max_depth
+        self.enable_thinking = enable_thinking
+        self.max_output_tokens = max_output_tokens
+        self.metadata_model = metadata_model
+        self._az_runner = az_runner if az_runner is not None else run_az
+        self._llm_runner = llm_runner
+        self._agent_runner = agent_runner
+
+    # ------------------------------------------------------------------
+    # Core pipeline methods
+    # ------------------------------------------------------------------
+
+    def solve(
+        self,
+        smiles: str,
+        visited: set[str] | None = None,
+        depth: int = 0,
+    ) -> tuple[dict[str, Any], bool]:
+        """Recursively solve one molecule via retrosynthesis.
+
+        Attempts AiZynthFinder first. On failure, falls back to the LLM
+        pipeline (or agent) and recursively solves each proposed precursor
+        until AZ solves every leaf.
+
+        Parameters
+        ----------
+        smiles : str
+            Molecule SMILES to solve.
+        visited : set[str], optional
+            Canonical SMILES already visited on the current branch.
+        depth : int, optional
+            Current recursion depth.
+
+        Returns
+        -------
+        tuple[dict[str, Any], bool]
+            Raw route tree and solved flag.
+
+        Examples
+        --------
+        >>> solver = AutoSolver(
+        ...     az_runner=lambda s, m: (False, []),
+        ...     llm_runner=lambda mol, **kw: ([], [], []),
+        ...     hallucination_mode="none",
+        ... )
+        >>> route, solved = solver.solve("CCO")  # doctest: +SKIP
+        >>> solved  # doctest: +SKIP
+        False
+        """
+        self._reject_orchestrator()
+        smiles = _clean_smiles(smiles)
+        if not smiles:
+            return unsolved_leaf(smiles), False
+
+        canonical = canonicalize(smiles)
+        if depth >= self.max_depth:
+            logger.warning("Maximum recursion depth reached", molecule=smiles)
+            return unsolved_leaf(smiles), False
+
+        branch_visited = set() if visited is None else set(visited)
+        if canonical in branch_visited:
+            logger.warning("Cycle detected in retrosynthesis tree", molecule=smiles)
+            return unsolved_leaf(smiles), False
+        branch_visited.add(canonical)
+
+        az_solved, az_routes, az_errored = self._run_az(smiles)
+        if az_errored:
+            return unsolved_leaf(smiles), False
+        if az_solved and az_routes:
+            logger.info("AiZynthFinder solved molecule", molecule=smiles)
+            return dict(az_routes[0]), True
+
+        pathways, _explanations, confidence = self.run_llm(smiles)
+        if not pathways:
+            logger.info("LLM fallback returned no usable pathways", molecule=smiles)
+            return unsolved_leaf(smiles), False
+
+        first_attempted_children: list[dict[str, Any]] | None = None
+        first_attempted_confidence: list[float] = []
+        for i, pathway in enumerate(pathways):
+            candidate_children, candidate_solved = self._solve_pathway(
+                pathway,
+                branch_visited,
+                depth,
+            )
+            if not candidate_children:
+                continue
+            if first_attempted_children is None:
+                first_attempted_children = candidate_children
+                first_attempted_confidence = (
+                    [confidence[i]] if i < len(confidence) else []
+                )
+            if candidate_solved:
+                selected_confidence = [confidence[i]] if i < len(confidence) else []
+                return (
+                    reaction_tree(smiles, candidate_children, selected_confidence),
+                    True,
+                )
+
+        if first_attempted_children is None:
+            return unsolved_leaf(smiles), False
+
+        return reaction_tree(
+            smiles, first_attempted_children, first_attempted_confidence
+        ), False
+
+    def single_step(
+        self,
+        smiles: str,
+    ) -> tuple[dict[str, Any], bool]:
+        """Run a single AZ + LLM retrosynthesis pass without recursion.
+
+        Unlike :meth:`solve`, this does not recurse into the proposed
+        precursors. Each precursor is returned as an unsolved leaf.
+
+        Parameters
+        ----------
+        smiles : str
+            Target molecule SMILES.
+
+        Returns
+        -------
+        tuple[dict[str, Any], bool]
+            Route tree (one level deep) and solved flag.
+
+        Examples
+        --------
+        >>> solver = AutoSolver(
+        ...     az_runner=lambda s, m: (False, []),
+        ...     llm_runner=lambda mol, **kw: ([], [], []),
+        ...     hallucination_mode="none",
+        ... )
+        >>> route, solved = solver.single_step("CCO")
+        >>> solved
+        False
+        """
+        self._reject_orchestrator()
+        smiles = _clean_smiles(smiles)
+        if not smiles:
+            return unsolved_leaf(smiles), False
+
+        az_solved, az_routes, az_errored = self._run_az(smiles)
+        if az_errored:
+            return unsolved_leaf(smiles), False
+        if az_solved and az_routes:
+            return dict(az_routes[0]), True
+
+        pathways, _explanations, confidence = self.run_llm(smiles)
+        if not pathways:
+            return unsolved_leaf(smiles), False
+
+        for i, pathway in enumerate(pathways):
+            reactants = _pathway_reactants(pathway)
+            if not reactants:
+                continue
+            children = [unsolved_leaf(reactant) for reactant in reactants]
+            selected_confidence = [confidence[i]] if i < len(confidence) else []
+            return reaction_tree(smiles, children, selected_confidence), False
+
+        return unsolved_leaf(smiles), False
+
+    def solve_multiple(
+        self,
+        smiles: str,
+        k: int = 3,
+    ) -> list[tuple[dict[str, Any], bool]]:
+        """Solve the top-``k`` candidate first-step pathways independently.
+
+        When AZ solves the target directly, a single solved route is returned.
+        Otherwise each of the first ``k`` LLM/agent pathways is solved with its
+        own fresh visited set, so shared reactants do not cross-contaminate
+        cycle detection. This produces the multiple routes the batch runner
+        writes as ``pathway_<i>.json``.
+
+        Parameters
+        ----------
+        smiles : str
+            Target molecule SMILES.
+        k : int, optional
+            Maximum number of candidate routes to return.
+
+        Returns
+        -------
+        list[tuple[dict[str, Any], bool]]
+            Up to ``k`` ``(route_tree, solved)`` tuples (at least one).
+
+        Examples
+        --------
+        >>> solver = AutoSolver(
+        ...     az_runner=lambda s, m: (True, [{"type": "mol", "smiles": s,
+        ...         "is_chemical": True, "in_stock": True}]),
+        ...     hallucination_mode="none",
+        ... )
+        >>> [solved for _, solved in solver.solve_multiple("CCO")]
+        [True]
+        """
+        self._reject_orchestrator()
+        smiles = _clean_smiles(smiles)
+        if not smiles:
+            return [(unsolved_leaf(smiles), False)]
+
+        az_solved, az_routes, az_errored = self._run_az(smiles)
+        if az_errored:
+            return [(unsolved_leaf(smiles), False)]
+        if az_solved and az_routes:
+            return [(dict(az_routes[0]), True)]
+
+        pathways, _explanations, confidence = self.run_llm(smiles)
+        if not pathways:
+            return [(unsolved_leaf(smiles), False)]
+
+        canonical = canonicalize(smiles)
+        results: list[tuple[dict[str, Any], bool]] = []
+        for i, pathway in enumerate(pathways[:k]):
+            # Fresh visited set per route so a reactant used by one candidate
+            # route is not treated as a cycle in another.
+            candidate_children, candidate_solved = self._solve_pathway(
+                pathway,
+                {canonical},
+                depth=0,
+            )
+            if not candidate_children:
+                continue
+            selected_confidence = [confidence[i]] if i < len(confidence) else []
+            results.append(
+                (
+                    reaction_tree(smiles, candidate_children, selected_confidence),
+                    candidate_solved,
+                )
+            )
+
+        if not results:
+            return [(unsolved_leaf(smiles), False)]
+        return results
+
+    def parse(self, route_tree: dict[str, Any], *, solved: bool) -> ParseOutput:
+        """Format a route tree into viewer-ready steps and dependencies.
+
+        Delegates to :func:`deepretro.utils.parse.format_output` and appends
+        the ``solved`` flag.
+
+        Parameters
+        ----------
+        route_tree : dict[str, Any]
+            Route tree from :meth:`solve` or :meth:`single_step`.
+        solved : bool
+            Whether the route was fully solved.
+
+        Returns
+        -------
+        dict[str, Any]
+            Parsed output with ``steps``, ``dependencies``, and ``solved`` keys.
+
+        Examples
+        --------
+        >>> from deepretro.algorithms.autosolve import unsolved_leaf
+        >>> solver = AutoSolver(hallucination_mode="none")
+        >>> result = solver.parse(unsolved_leaf("CCO"), solved=False)
+        >>> result["solved"]
+        False
+        """
+        output = format_output(route_tree)
+        output["solved"] = solved
+        return output
+
+    def add_metadata(
+        self,
+        parsed_output: ParseOutput,
+        *,
+        reagent_recommender: ReagentRecommender | None = None,
+        conditions_recommender: ConditionsRecommender | None = None,
+        literature_recommender: LiteratureRecommender | None = None,
+    ) -> ParseOutput:
+        """Enrich parsed steps with reagent, condition, and literature metadata.
+
+        Iterates each step, builds a ``reactants>>product`` reaction SMILES,
+        and calls :func:`deepretro.metadata.recommend_reaction_metadata`.
+
+        Parameters
+        ----------
+        parsed_output : dict[str, Any]
+            Output from :meth:`parse`.
+        reagent_recommender : callable, optional
+            Override the default reagent prediction agent.
+        conditions_recommender : callable, optional
+            Override the default conditions prediction agent.
+        literature_recommender : callable, optional
+            Override the default literature prediction agent.
+
+        Returns
+        -------
+        dict[str, Any]
+            The same dict with each step enriched in-place.
+
+        Examples
+        --------
+        >>> solver = AutoSolver(hallucination_mode="none")
+        >>> solver.add_metadata({"steps": [], "dependencies": {}, "solved": True})
+        {'steps': [], 'dependencies': {}, 'solved': True}
+        """
+        for step in parsed_output.get("steps", []):
+            reactant_smiles = ".".join(r["smiles"] for r in step.get("reactants", []))
+            product_smiles = (
+                step["products"][0]["smiles"] if step.get("products") else ""
+            )
+            if not reactant_smiles or not product_smiles:
+                continue
+
+            from deepretro.metadata import recommend_reaction_metadata
+
+            reaction_smiles = f"{reactant_smiles}>>{product_smiles}"
+            status, result = recommend_reaction_metadata(
+                reaction_smiles,
+                model=self.metadata_model,
+                reagent_recommender=reagent_recommender,
+                conditions_recommender=conditions_recommender,
+                literature_recommender=literature_recommender,
+                cache=None,
+            )
+            if status != 200:
+                logger.info(
+                    "metadata recommendation failed",
+                    step=step.get("step"),
+                    status=status,
+                )
+                continue
+
+            step["reagents"] = result.get("reagents", [])
+            step["conditions"] = result.get("conditions", {})
+            reactionmetrics = step.setdefault("reactionmetrics", [])
+            if not reactionmetrics:
+                reactionmetrics.append({"scalabilityindex": 0, "closestliterature": ""})
+            # ``literature`` is the recommender payload (typically a
+            # ``{"doi": ...}`` mapping); ``closestliterature`` is a string DOI.
+            literature = result.get("literature", "")
+            if isinstance(literature, dict):
+                literature = literature.get("doi", "")
+            reactionmetrics[0]["closestliterature"] = literature
+
+        return parsed_output
+
+    def autosolve(self, smiles: str) -> ParseOutput:
+        """Run the full retrosynthesis pipeline: solve, parse, and enrich.
+
+        Parameters
+        ----------
+        smiles : str
+            Target molecule SMILES.
+
+        Returns
+        -------
+        dict[str, Any]
+            Fully enriched output with steps, dependencies, metadata, and
+            solved status.
+
+        Examples
+        --------
+        >>> solver = AutoSolver(
+        ...     az_runner=lambda s, m: (False, []),
+        ...     llm_runner=lambda mol, **kw: ([], [], []),
+        ...     hallucination_mode="none",
+        ... )
+        >>> output = solver.autosolve("CCO")  # doctest: +SKIP
+        >>> output["solved"]  # doctest: +SKIP
+        False
+        """
+        smiles = _clean_smiles(smiles)
+        log = logger.bind(
+            job_id=(f"{time.strftime('%Y%m%d_%H%M%S')}_{os.getpid()}_{time.time_ns()}")
+        )
+        log.info("AutoSolver starting", molecule=smiles)
+
+        route_tree, solved = self.solve(smiles)
+        output = self.parse(route_tree, solved=solved)
+        output = self.add_metadata(output)
+
+        log.info("AutoSolver completed", molecule=smiles, solved=solved)
+        return output
+
+    def run_llm(
+        self,
+        molecule: str,
+    ) -> tuple[list[Pathway], list[str], list[float]]:
+        """Obtain candidate pathways and apply all safety filters.
+
+        This is the single owner of validity, stability, and hallucination
+        filtering. In ``pipeline`` mode the LLM pipeline already applies
+        validity and stability, so only hallucination is applied here. In
+        ``single_step_agent`` mode the raw agent output is passed through the
+        full validity → stability → hallucination filter chain, so the agent
+        can never bypass the safety net.
+
+        Parameters
+        ----------
+        molecule : str
+            Target molecule SMILES for the LLM/agent call.
+
+        Returns
+        -------
+        tuple[list[Pathway], list[str], list[float]]
+            Filtered pathways, explanations, and confidence scores.
+
+        Examples
+        --------
+        >>> solver = AutoSolver(
+        ...     llm_runner=lambda mol, **kw: ([["CCO"]], ["reduction"], [0.8]),
+        ...     hallucination_mode="none",
+        ... )
+        >>> pathways, explanations, confidence = solver.run_llm("CC=O")
+        >>> pathways
+        [['CCO']]
+        """
+        if self.solve_mode == "single_step_agent":
+            pathways, explanations, confidence = self._run_agent(molecule)
+            pathways, explanations, confidence = self._apply_safety_filters(
+                molecule, pathways, explanations, confidence
+            )
+        else:
+            pathways, explanations, confidence = self._run_pipeline(molecule)
+
+        return filter_with_checker(
+            molecule,
+            pathways,
+            explanations,
+            confidence,
+            self.hallucination_checker,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _reject_orchestrator(self) -> None:
+        """Raise for the not-yet-implemented top-level orchestrator mode."""
+        if self.solve_mode == "orchestrator":
+            raise NotImplementedError(
+                "solve_mode='orchestrator' is not implemented yet; use "
+                "'pipeline' or 'single_step_agent'"
+            )
+
+    def _run_az(self, smiles: str) -> tuple[bool, list[Any], bool]:
+        """Call the AZ runner, converting any failure into an error flag.
+
+        Returns ``(solved, routes, errored)``. AiZynthFinder is an external,
+        occasionally-misconfigured tool (missing model files raise
+        ``FileNotFoundError``/``ImportError``); a broad guard keeps one node's
+        failure from crashing the whole solve.
+        """
+        try:
+            solved, routes = self._az_runner(smiles, self.az_model)
+            return solved, list(routes), False
+        except Exception as exc:  # ponytail: AZ is external; never crash a solve
+            logger.error("AZ runner failed", molecule=smiles, error=str(exc))
+            return False, [], True
+
+    def _run_pipeline(
+        self, molecule: str
+    ) -> tuple[list[Pathway], list[str], list[float]]:
+        """Get raw pathways from the non-agentic LLM pipeline."""
+        runner = self._llm_runner
+        if runner is None:
+            from deepretro.utils.llm import llm_pipeline
+
+            runner = llm_pipeline
+        return runner(
+            molecule,
+            model=self.llm,
+            stability_check=self.stability_check,
+            hallucination_check=False,
+            enable_thinking=self.enable_thinking,
+            max_output_tokens=self.max_output_tokens,
+        )
+
+    def _run_agent(self, molecule: str) -> tuple[list[Pathway], list[str], list[float]]:
+        """Get raw pathways from the tool-calling agent."""
+        runner = self._agent_runner
+        if runner is None:
+            from deepretro.agents.loop import agentic_single_step
+
+            runner = agentic_single_step
+        return runner(
+            molecule,
+            model=self.llm,
+            tool_backend=self.tool_backend,
+            sandbox=self.sandbox,
+            enable_thinking=self.enable_thinking,
+            max_output_tokens=self.max_output_tokens,
+        )
+
+    def _apply_safety_filters(
+        self,
+        molecule: str,
+        pathways: list[Pathway],
+        explanations: list[str],
+        confidence: list[float],
+    ) -> tuple[list[Pathway], list[str], list[float]]:
+        """Apply validity then optional stability filtering, keeping alignment."""
+        pathways, explanations, confidence = validity_check(
+            molecule, pathways, explanations, confidence
+        )
+        if self.stability_check:
+            from deepretro.utils.llm import (
+                filter_metadata_by_pathways,
+                filter_stable_pathways,
+            )
+
+            stable = filter_stable_pathways(pathways)
+            pathways, explanations, confidence = filter_metadata_by_pathways(
+                stable, pathways, explanations, confidence
+            )
+        return pathways, explanations, confidence
+
+    def _solve_pathway(
+        self,
+        pathway: Sequence[str] | str,
+        visited: set[str],
+        depth: int,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Solve each reactant in a candidate precursor pathway.
+
+        Parameters
+        ----------
+        pathway : Sequence[str] or str
+            One or more reactant SMILES from a candidate retrosynthesis step.
+        visited : set[str]
+            Canonical SMILES already visited on the current branch.
+        depth : int
+            Current recursion depth.
+
+        Returns
+        -------
+        tuple[list[dict[str, Any]], bool]
+            Solved child route nodes and whether all reactants were solved.
+        """
+        reactants = _pathway_reactants(pathway)
+        if not reactants:
+            return [], False
+        children: list[dict[str, Any]] = []
+        all_solved = True
+        for reactant in reactants:
+            child, solved = self.solve(reactant, visited, depth + 1)
+            children.append(child)
+            all_solved = all_solved and solved
+        return children, all_solved
+
+
+# ----------------------------------------------------------------------
+# Module-level route tree builders
+# ----------------------------------------------------------------------
+
+
+def unsolved_leaf(smiles: str) -> dict[str, Any]:
+    """Build a terminal route node for an unresolved molecule.
+
+    Parameters
+    ----------
+    smiles : str
+        SMILES of the unresolved molecule.
+
+    Returns
+    -------
+    dict[str, Any]
+        Route node with ``in_stock=False`` and empty children.
+
+    Examples
+    --------
+    >>> unsolved_leaf("CCO")["in_stock"]
+    False
+    """
+    return {
+        "type": "mol",
+        "smiles": smiles,
+        "is_chemical": True,
+        "in_stock": False,
+        "children": [],
+    }
+
+
+def _clean_smiles(smiles: str) -> str:
+    """Validate and strip surrounding whitespace from a SMILES string.
+
+    Parameters
+    ----------
+    smiles : str
+        Raw SMILES input.
+
+    Returns
+    -------
+    str
+        The stripped SMILES string.
+
+    Raises
+    ------
+    TypeError
+        If *smiles* is not a string.
+
+    Examples
+    --------
+    >>> _clean_smiles("  CCO  ")
+    'CCO'
+    """
+    if not isinstance(smiles, str):
+        raise TypeError("smiles must be a string")
+    return smiles.strip()
+
+
+def _pathway_reactants(pathway: Sequence[str] | str) -> list[str]:
+    """Normalize a pathway into a list of non-empty reactant SMILES.
+
+    Parameters
+    ----------
+    pathway : Sequence[str] or str
+        A single reactant string or a sequence of reactant SMILES.
+
+    Returns
+    -------
+    list[str]
+        Stripped, non-empty reactant SMILES.
+
+    Raises
+    ------
+    TypeError
+        If a sequence element is not a string.
+
+    Examples
+    --------
+    >>> _pathway_reactants(["CCO", " ", "O"])
+    ['CCO', 'O']
+    >>> _pathway_reactants("CC=O")
+    ['CC=O']
+    """
+    if isinstance(pathway, str):
+        return [pathway.strip()] if pathway.strip() else []
+
+    reactants: list[str] = []
+    for reactant in pathway:
+        if not isinstance(reactant, str):
+            raise TypeError("pathway reactants must be strings")
+        reactant = reactant.strip()
+        if reactant:
+            reactants.append(reactant)
+    return reactants
+
+
+def reaction_tree(
+    molecule: str,
+    children: Sequence[RouteNode],
+    confidence: Sequence[float],
+) -> dict[str, Any]:
+    """Build the route-tree shape consumed by ``RetrosynthesisRouteParser``.
+
+    Parameters
+    ----------
+    molecule : str
+        Parent molecule SMILES.
+    children : Sequence[RouteNode]
+        Solved child route nodes (reactants).
+    confidence : Sequence[float]
+        Confidence scores from the LLM pipeline; the first value is used as
+        ``policy_probability``.
+
+    Returns
+    -------
+    dict[str, Any]
+        Nested route tree with a single reaction child node.
+
+    Examples
+    --------
+    >>> tree = reaction_tree("CCO", [unsolved_leaf("C"), unsolved_leaf("O")], [0.8])
+    >>> tree["smiles"]
+    'CCO'
+    >>> tree["children"][0]["metadata"]["policy_probability"]
+    0.8
+    """
+    policy_probability = float(confidence[0]) if confidence else 0.0
+    return {
+        "type": "mol",
+        "smiles": molecule,
+        "is_chemical": True,
+        "in_stock": False,
+        "children": [
+            {
+                "type": "reaction",
+                "is_reaction": True,
+                "metadata": {"policy_probability": policy_probability},
+                "children": list(children),
+            }
+        ],
+    }

--- a/deepretro/algorithms/autosolve.py
+++ b/deepretro/algorithms/autosolve.py
@@ -630,6 +630,7 @@ class AutoSolver:
             model=self.llm,
             tool_backend=self.tool_backend,
             sandbox=self.sandbox,
+            hallucination_checker=self.hallucination_checker,
             enable_thinking=self.enable_thinking,
             max_output_tokens=self.max_output_tokens,
         )

--- a/deepretro/batch.py
+++ b/deepretro/batch.py
@@ -1,0 +1,359 @@
+"""Batch retrosynthesis runner.
+
+End-to-end driver: download a CSV from a public Google Sheet, (optionally) train
+the hallucination checker, read target molecules from a text file, run each
+through :class:`deepretro.algorithms.autosolve.AutoSolver`, and dump the routes
+as ``<out>/<timestamp>/<molecule>/pathway_<i>.json``.
+
+The training step is a **template** (see :func:`train_hallucination_checker`): it
+runs only when the CSV carries the expected labelled columns, and otherwise logs
+and falls back to the heuristic hallucination mode so the batch still runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Solver hook: molecule SMILES -> list of parsed pathway dicts.
+SolveMolecule = Callable[[str], list[dict[str, Any]]]
+# HTTP hook: (url, timeout) -> response with ``content`` and ``raise_for_status``.
+HttpGet = Callable[..., Any]
+
+REQUIRED_TRAINING_COLUMNS = {"product", "reactants", "label"}
+
+
+def read_molecules(path: str) -> list[str]:
+    """Read target SMILES from a text file (one per line).
+
+    Blank lines and lines starting with ``#`` are skipped; surrounding
+    whitespace is stripped.
+
+    Parameters
+    ----------
+    path : str
+        Path to the molecules file.
+
+    Returns
+    -------
+    list[str]
+        Target SMILES strings.
+
+    Examples
+    --------
+    >>> import tempfile, os
+    >>> path = os.path.join(tempfile.mkdtemp(), "m.txt")
+    >>> _ = open(path, "w").write("CCO\\n# note\\n\\nCCN\\n")
+    >>> read_molecules(path)
+    ['CCO', 'CCN']
+    """
+    molecules: list[str] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        molecules.append(stripped)
+    return molecules
+
+
+def slugify_molecule(smiles: str) -> str:
+    """Build a filesystem-safe, unique directory name for a molecule.
+
+    Combines a readable ASCII-safe prefix with a short hash of the original
+    SMILES so distinct molecules never collide and the same SMILES is stable.
+
+    Parameters
+    ----------
+    smiles : str
+        Molecule SMILES.
+
+    Returns
+    -------
+    str
+        A safe directory name.
+
+    Examples
+    --------
+    >>> slugify_molecule("CCO") == slugify_molecule("CCO")
+    True
+    >>> "/" in slugify_molecule("CC(=O)O")
+    False
+    """
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", smiles)[:60]
+    digest = hashlib.md5(smiles.encode("utf-8")).hexdigest()[:8]
+    return f"{safe}_{digest}"
+
+
+def download_sheet_csv(
+    url: str,
+    dest: str,
+    *,
+    http_get: HttpGet | None = None,
+) -> str:
+    """Download a published Google Sheet CSV export to *dest*.
+
+    Parameters
+    ----------
+    url : str
+        The sheet's ``/export?format=csv`` URL (published / link-shared; no
+        auth is used).
+    dest : str
+        Local path to write the CSV to.
+    http_get : callable, optional
+        Injectable HTTP getter (defaults to ``requests.get``). Must return a
+        response exposing ``content`` and ``raise_for_status``.
+
+    Returns
+    -------
+    str
+        The destination path.
+
+    Raises
+    ------
+    Exception
+        Whatever ``raise_for_status`` raises on a non-2xx response.
+    """
+    if http_get is None:
+        import requests
+
+        http_get = requests.get
+    response = http_get(url, timeout=60)
+    response.raise_for_status()
+    Path(dest).write_bytes(response.content)
+    logger.info("Downloaded sheet CSV", url=url, dest=dest)
+    return dest
+
+
+def train_hallucination_checker(csv_path: str, save_dir: str) -> str | None:
+    """Train the ML hallucination checker from a labelled CSV (TEMPLATE).
+
+    Runs only when the CSV has ``product``/``reactants``/``label`` columns;
+    otherwise logs and returns ``None`` so the batch falls back to the
+    heuristic checker. The training body is a template for a downstream
+    contributor to complete/tune for their dataset; any failure degrades to
+    ``None`` rather than aborting the batch.
+
+    Parameters
+    ----------
+    csv_path : str
+        Path to the training CSV.
+    save_dir : str
+        Directory to save the trained model into.
+
+    Returns
+    -------
+    str or None
+        ``save_dir`` when a model was trained and saved, else ``None``.
+    """
+    import pandas as pd
+
+    columns = set(pd.read_csv(csv_path, nrows=0).columns)
+    if not REQUIRED_TRAINING_COLUMNS.issubset(columns):
+        logger.warning(
+            "Training CSV missing required columns; skipping training (template)",
+            required=sorted(REQUIRED_TRAINING_COLUMNS),
+            found=sorted(columns),
+        )
+        return None
+
+    try:
+        # --- TEMPLATE: adapt featurization/splitting/hyperparameters as needed ---
+        from deepretro.data.loader import ReactionDataLoader, stratified_split
+        from deepretro.models import HallucinationClassifier
+
+        loader = ReactionDataLoader()
+        dataset = loader.create_dataset(csv_path)
+        train_ds, _valid_ds, test_ds = stratified_split(dataset)
+
+        Path(save_dir).mkdir(parents=True, exist_ok=True)
+        classifier = HallucinationClassifier(model_dir=save_dir)
+        classifier.fit(train_ds)
+        classifier.evaluate(test_ds)
+        classifier.save(save_dir)
+        # --- end template ---
+        logger.info("Trained hallucination checker", save_dir=save_dir)
+        return save_dir
+    except Exception as exc:  # ponytail: template; never abort the batch on training
+        logger.error("Hallucination training failed; using heuristic", error=str(exc))
+        return None
+
+
+def solve_molecule(solver: Any, smiles: str, top_k: int) -> list[dict[str, Any]]:
+    """Solve one molecule into up to ``top_k`` parsed, enriched pathway dicts.
+
+    Parameters
+    ----------
+    solver : AutoSolver
+        Any object exposing ``solve_multiple``, ``parse``, and ``add_metadata``.
+    smiles : str
+        Target molecule SMILES.
+    top_k : int
+        Maximum number of candidate routes.
+
+    Returns
+    -------
+    list[dict]
+        Parsed pathway dicts, each tagged with its ``target`` SMILES.
+    """
+    pathways: list[dict[str, Any]] = []
+    for route, solved in solver.solve_multiple(smiles, k=top_k):
+        parsed = solver.parse(route, solved=solved)
+        parsed = solver.add_metadata(parsed)
+        parsed["target"] = smiles
+        pathways.append(parsed)
+    return pathways
+
+
+def run_batch(
+    molecules: list[str],
+    out_dir: str,
+    *,
+    timestamp: str,
+    solve: SolveMolecule,
+) -> dict[str, list[str]]:
+    """Run each molecule and write its routes under ``out_dir/timestamp/molecule``.
+
+    A per-molecule failure writes ``error.json`` and never aborts the batch.
+
+    Parameters
+    ----------
+    molecules : list[str]
+        Target SMILES.
+    out_dir : str
+        Root output directory.
+    timestamp : str
+        Run timestamp used as the second path level.
+    solve : callable
+        ``smiles -> list[dict]`` producing the parsed pathways for a molecule.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        Map from each molecule to the file paths written for it.
+    """
+    run_dir = Path(out_dir) / timestamp
+    written: dict[str, list[str]] = {}
+
+    for smiles in molecules:
+        mol_dir = run_dir / slugify_molecule(smiles)
+        mol_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            pathways = solve(smiles)
+            paths: list[str] = []
+            for index, pathway in enumerate(pathways, start=1):
+                target = mol_dir / f"pathway_{index}.json"
+                target.write_text(json.dumps(pathway, indent=2), encoding="utf-8")
+                paths.append(str(target))
+            written[smiles] = paths
+            logger.info("Wrote pathways", molecule=smiles, count=len(paths))
+        except Exception as exc:  # ponytail: one bad molecule must not kill the run
+            error_file = mol_dir / "error.json"
+            error_file.write_text(
+                json.dumps({"smiles": smiles, "error": str(exc)}, indent=2),
+                encoding="utf-8",
+            )
+            written[smiles] = [str(error_file)]
+            logger.error("Molecule failed", molecule=smiles, error=str(exc))
+
+    return written
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build the batch runner argument parser."""
+    parser = argparse.ArgumentParser(
+        description="DeepRetro batch retrosynthesis runner"
+    )
+    parser.add_argument(
+        "--sheet-url",
+        required=True,
+        help="Google Sheets /export?format=csv URL (public/link-shared). "
+        "TODO: supply the sheet URL.",
+    )
+    parser.add_argument(
+        "--molecules",
+        required=True,
+        help="Path to a text file of target SMILES (one per line). "
+        "TODO: supply the molecules file.",
+    )
+    parser.add_argument("--out", default="batch_output", help="Output directory root")
+    parser.add_argument(
+        "--csv", default="hallucination_data.csv", help="CSV download path"
+    )
+    parser.add_argument(
+        "--solve-mode",
+        choices=["pipeline", "single_step_agent"],
+        default="pipeline",
+        help="Retrosynthesis mode (orchestrator is not offered)",
+    )
+    parser.add_argument(
+        "--tool-backend", choices=["structured", "sandbox"], default="structured"
+    )
+    parser.add_argument("--model", default="anthropic/claude-sonnet-4-6")
+    parser.add_argument("--az-model", default="USPTO")
+    parser.add_argument(
+        "--classifier",
+        default=None,
+        help="Path to a trained hallucination model dir (enables ML mode)",
+    )
+    parser.add_argument("--top-k", type=int, default=3)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the batch pipeline from the command line.
+
+    Parameters
+    ----------
+    argv : list[str], optional
+        Argument vector (defaults to ``sys.argv``).
+    """
+    args = _build_arg_parser().parse_args(argv)
+    timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
+
+    download_sheet_csv(args.sheet_url, args.csv)
+
+    classifier_dir = args.classifier or train_hallucination_checker(
+        args.csv, str(Path(args.out) / "hallucination_model")
+    )
+    hallucination_mode = "ml" if classifier_dir else "heuristic"
+
+    molecules = read_molecules(args.molecules)
+    logger.info(
+        "Starting batch",
+        molecules=len(molecules),
+        timestamp=timestamp,
+        solve_mode=args.solve_mode,
+        hallucination_mode=hallucination_mode,
+    )
+
+    from deepretro.algorithms.autosolve import AutoSolver
+
+    solver = AutoSolver(
+        llm=args.model,
+        az_model=args.az_model,
+        solve_mode=args.solve_mode,
+        tool_backend=args.tool_backend,
+        hallucination_mode=hallucination_mode,
+        hallucination_classifier=classifier_dir,
+    )
+
+    run_batch(
+        molecules,
+        args.out,
+        timestamp=timestamp,
+        solve=lambda smiles: solve_molecule(solver, smiles, args.top_k),
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/deepretro/models/hallucination_helpers.py
+++ b/deepretro/models/hallucination_helpers.py
@@ -10,11 +10,13 @@ Provides:
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
 from deepretro.models.hallucination_classifier import predict_single_reaction
+from deepretro.utils.llm_helpers import Pathway
+from deepretro.utils.typing import HallucinationChecker
 
 
 class MLChecker:
@@ -143,6 +145,7 @@ def resolve_hallucination(
         return None
     if mode == "heuristic":
         from deepretro.algorithms.pipeline_checks import hallucination_checker
+
         return hallucination_checker
     if mode == "ml":
         from deepretro.models.hallucination_classifier import HallucinationClassifier
@@ -161,3 +164,112 @@ def resolve_hallucination(
     raise ValueError(
         f"hallucination_mode must be 'heuristic', 'ml', or 'none' — got {mode!r}"
     )
+
+
+def _as_pathway(candidate: Pathway | str) -> Pathway:
+    """Normalize one candidate into a list-of-SMILES pathway.
+
+    Parameters
+    ----------
+    candidate : list[str] or str
+        A pathway as a list of reactant SMILES, or a single reactant SMILES.
+
+    Returns
+    -------
+    list[str]
+        The candidate as a list, so string and list pathways compare equal.
+    """
+    return [candidate] if isinstance(candidate, str) else list(candidate)
+
+
+def filter_with_checker(
+    product: str,
+    pathways: list[Pathway],
+    explanations: Iterable[str],
+    confidence: Iterable[float],
+    checker: HallucinationChecker | None,
+) -> tuple[list[Pathway], list[str], list[float]]:
+    """Filter pathways with a checker while keeping metadata aligned.
+
+    A checker returns only the kept pathways, not their indices, so the
+    explanations and confidence scores must be realigned to the surviving
+    pathways. Alignment is by value (order-preserving), which is why a
+    checker must only ever return pathways from its input.
+
+    Parameters
+    ----------
+    product : str
+        Product molecule SMILES.
+    pathways : list[list[str]]
+        Candidate precursor pathways.
+    explanations : Iterable[str]
+        Explanations aligned position-for-position with ``pathways``.
+    confidence : Iterable[float]
+        Confidence scores aligned position-for-position with ``pathways``.
+    checker : HallucinationChecker or None
+        Optional pathway filter ``(product, pathways) -> (status, kept)``.
+        ``None`` disables filtering and returns the inputs unchanged.
+
+    Returns
+    -------
+    tuple[list[list[str]], list[str], list[float]]
+        Retained pathways with explanations and confidence realigned.
+        A checker status other than 200 yields three empty lists.
+
+    Raises
+    ------
+    ValueError
+        If ``pathways``, ``explanations``, and ``confidence`` differ in
+        length, or if the checker returns a pathway absent from the input.
+
+    Examples
+    --------
+    >>> filter_with_checker(
+    ...     "CC(=O)Oc1ccccc1C(=O)O",
+    ...     [["OC(=O)c1ccccc1O"], ["CC(=O)O"]],
+    ...     ["hydrolysis", "deacetylation"],
+    ...     [0.3, 0.9],
+    ...     None,
+    ... )
+    ([['OC(=O)c1ccccc1O'], ['CC(=O)O']], ['hydrolysis', 'deacetylation'], [0.3, 0.9])
+    """
+    explanation_list = list(explanations)
+    confidence_list = list(confidence)
+    if len(pathways) != len(explanation_list) or len(pathways) != len(confidence_list):
+        raise ValueError(
+            f"pathways ({len(pathways)}), explanations ({len(explanation_list)}), "
+            f"and confidence ({len(confidence_list)}) must have the same length"
+        )
+
+    if checker is None or not pathways:
+        return list(pathways), explanation_list, confidence_list
+
+    status, retained_pathways = checker(product, pathways)
+    if status != 200:
+        return [], [], []
+
+    available = [
+        (_as_pathway(pathway), explanation, score)
+        for pathway, explanation, score in zip(
+            pathways, explanation_list, confidence_list
+        )
+    ]
+    matched_pathways: list[Pathway] = []
+    matched_explanations: list[str] = []
+    matched_confidence: list[float] = []
+
+    for retained in retained_pathways:
+        target = _as_pathway(retained)
+        for index, (normalized, explanation, score) in enumerate(available):
+            if normalized == target:
+                matched_pathways.append(retained)
+                matched_explanations.append(explanation)
+                matched_confidence.append(float(score))
+                available.pop(index)
+                break
+        else:
+            raise ValueError(
+                f"Checker returned pathway {retained!r} not present in original input"
+            )
+
+    return matched_pathways, matched_explanations, matched_confidence

--- a/deepretro/pyproject.toml
+++ b/deepretro/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "litellm",
     "python-dotenv",
     "langfuse<3",
+    "requests",
 ]
 
 [project.optional-dependencies]

--- a/deepretro/tests/test_agents_loop.py
+++ b/deepretro/tests/test_agents_loop.py
@@ -1,0 +1,109 @@
+"""Tests for the single-step tool-calling agent loop."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from deepretro.agents.loop import agentic_orchestrator, agentic_single_step
+
+MODEL = "openai/gpt-4o-mini"
+FINAL_ANSWER = (
+    '<json>{"data": [["CCO"]], "explanation": ["reduce"], '
+    '"confidence_scores": [0.8]}</json>'
+)
+
+
+def final_turn(content: str = FINAL_ANSWER) -> dict[str, Any]:
+    """An assistant turn with no tool calls (a final answer)."""
+    return {"role": "assistant", "content": content}
+
+
+def tool_turn(
+    name: str = "validate_smiles",
+    arguments: dict[str, Any] | None = None,
+    call_id: str = "call_1",
+) -> dict[str, Any]:
+    """An assistant turn requesting one tool call."""
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": json.dumps(arguments or {"smiles": "CCO"}),
+                },
+            }
+        ],
+    }
+
+
+class ScriptedModel:
+    """Injectable model that replays scripted turns and records inputs."""
+
+    def __init__(self, turns: list[dict[str, Any]]) -> None:
+        self.turns = list(turns)
+        self.seen: list[list[dict[str, Any]]] = []
+
+    def __call__(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
+        self.seen.append([dict(message) for message in messages])
+        return self.turns[len(self.seen) - 1]
+
+
+def test_returns_parsed_pathways_from_final_answer() -> None:
+    """A final answer is parsed into the pipeline's (pathways, expl, conf) shape."""
+    model = ScriptedModel([final_turn()])
+    pathways, explanations, confidence = agentic_single_step(
+        "CC=O", MODEL, llm_runner=model
+    )
+    assert pathways == [["CCO"]]
+    assert explanations == ["reduce"]
+    assert confidence == [0.8]
+
+
+def test_executes_tool_then_returns_final_answer() -> None:
+    """A tool call is executed and its result fed back before the final answer."""
+    model = ScriptedModel([tool_turn(), final_turn()])
+    pathways, _explanations, _confidence = agentic_single_step(
+        "CC=O", MODEL, llm_runner=model
+    )
+    assert pathways == [["CCO"]]
+    second_call_messages = model.seen[1]
+    assert any(message.get("role") == "tool" for message in second_call_messages)
+
+
+def test_tool_result_references_call_id() -> None:
+    """The tool result message references the originating tool_call id."""
+    model = ScriptedModel([tool_turn(call_id="abc123"), final_turn()])
+    agentic_single_step("CC=O", MODEL, llm_runner=model)
+    tool_messages = [m for m in model.seen[1] if m.get("role") == "tool"]
+    assert tool_messages[0]["tool_call_id"] == "abc123"
+
+
+def test_hits_max_iterations_returns_empty() -> None:
+    """Looping without a final answer returns empty results after the cap."""
+
+    def always_tool(messages: list[dict[str, Any]]) -> dict[str, Any]:
+        return tool_turn()
+
+    result = agentic_single_step(
+        "CC=O", MODEL, llm_runner=always_tool, max_iterations=3
+    )
+    assert result == ([], [], [])
+
+
+def test_unparseable_final_answer_returns_empty() -> None:
+    """A final answer without a valid JSON payload yields empty results."""
+    model = ScriptedModel([final_turn(content="I could not find a route.")])
+    assert agentic_single_step("CC=O", MODEL, llm_runner=model) == ([], [], [])
+
+
+def test_orchestrator_raises_not_implemented() -> None:
+    """The top-level orchestrator is a scaffold and raises when invoked."""
+    with pytest.raises(NotImplementedError, match="orchestrator"):
+        agentic_orchestrator("CCO", MODEL)

--- a/deepretro/tests/test_agents_sandbox.py
+++ b/deepretro/tests/test_agents_sandbox.py
@@ -1,0 +1,75 @@
+"""Tests for the subprocess code-execution sandbox."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from deepretro.agents.sandbox import SandboxResult, SubprocessSandbox
+
+
+def test_runs_code_and_captures_stdout() -> None:
+    """A successful run returns ok with the captured stdout."""
+    result = SubprocessSandbox().run("print('hello world')")
+    assert isinstance(result, SandboxResult)
+    assert result.ok is True
+    assert "hello world" in result.stdout
+
+
+def test_reports_error_on_exception() -> None:
+    """An exception in the code is reported as not-ok with a traceback."""
+    result = SubprocessSandbox().run("raise ValueError('boom')")
+    assert result.ok is False
+    assert "ValueError" in result.stderr
+
+
+def test_installed_packages_are_importable() -> None:
+    """RDKit (an installed dependency) imports despite the scrubbed env."""
+    result = SubprocessSandbox().run(
+        "from rdkit import Chem; print(Chem.CanonSmiles('C(O)C'))"
+    )
+    assert result.ok is True
+    assert "CCO" in result.stdout
+
+
+def test_scrubs_secrets_from_child_env() -> None:
+    """API keys in the parent environment are not visible to sandboxed code."""
+    os.environ["ANTHROPIC_API_KEY"] = "super-secret-value"
+    try:
+        result = SubprocessSandbox().run(
+            "import os; print(os.environ.get('ANTHROPIC_API_KEY', 'ABSENT'))"
+        )
+    finally:
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+    assert result.ok is True
+    assert "super-secret-value" not in result.stdout
+    assert "ABSENT" in result.stdout
+
+
+def test_times_out_on_long_running_code() -> None:
+    """Wall-clock timeout kills the child and reports a timeout error."""
+    result = SubprocessSandbox().run("import time; time.sleep(30)", timeout_s=1.0)
+    assert result.ok is False
+    assert "tim" in result.error.lower()
+
+
+def test_working_directory_is_ephemeral() -> None:
+    """The sandbox runs in a temp cwd that is removed after the run."""
+    result = SubprocessSandbox().run("import os; print(os.getcwd())")
+    assert result.ok is True
+    workdir = result.stdout.strip().splitlines()[-1]
+    assert not os.path.exists(workdir)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="RLIMIT_AS is not enforced on macOS",
+)
+def test_memory_limit_blocks_large_allocation() -> None:
+    """A large allocation is blocked by the address-space limit (Linux only)."""
+    result = SubprocessSandbox().run(
+        "x = bytearray(4 * 1024 * 1024 * 1024)", mem_mb=256
+    )
+    assert result.ok is False

--- a/deepretro/tests/test_agents_tools.py
+++ b/deepretro/tests/test_agents_tools.py
@@ -1,0 +1,109 @@
+"""Tests for the agent tool registry, executors, and dispatcher."""
+
+from __future__ import annotations
+
+from deepretro.agents.sandbox import SubprocessSandbox
+from deepretro.agents.tools import build_tool_registry
+
+
+def keep_all(product: str, pathways: list) -> tuple[int, list]:
+    """Hallucination checker double that keeps every pathway."""
+    del product
+    return 200, pathways
+
+
+def reject_all(product: str, pathways: list) -> tuple[int, list]:
+    """Hallucination checker double that rejects every pathway."""
+    del product, pathways
+    return 400, []
+
+
+class TestValidateSmiles:
+    def test_valid_smiles_returns_canonical(self) -> None:
+        registry = build_tool_registry()
+        result = registry.execute("validate_smiles", {"smiles": "C(O)C"})
+        assert result["valid"] is True
+        assert result["canonical_smiles"] == "CCO"
+
+    def test_invalid_smiles_reports_error(self) -> None:
+        registry = build_tool_registry()
+        result = registry.execute("validate_smiles", {"smiles": "not_a_smiles!!!"})
+        assert result["valid"] is False
+        assert result["error"]
+
+
+class TestCheckStability:
+    def test_returns_assessment(self) -> None:
+        registry = build_tool_registry()
+        result = registry.execute("check_stability", {"smiles": "CCO"})
+        assert "assessment" in result
+        assert "stability_score" in result
+
+
+class TestCheckHallucination:
+    def test_registered_when_checker_provided(self) -> None:
+        registry = build_tool_registry(hallucination_checker=keep_all)
+        assert "check_hallucination" in registry.names
+
+    def test_omitted_when_no_checker(self) -> None:
+        registry = build_tool_registry(hallucination_checker=None)
+        assert "check_hallucination" not in registry.names
+
+    def test_keep_all_reports_not_hallucination(self) -> None:
+        registry = build_tool_registry(hallucination_checker=keep_all)
+        result = registry.execute(
+            "check_hallucination", {"product": "CCO", "reactants": ["CC", "O"]}
+        )
+        assert result["is_hallucination"] is False
+
+    def test_reject_all_reports_hallucination(self) -> None:
+        registry = build_tool_registry(hallucination_checker=reject_all)
+        result = registry.execute(
+            "check_hallucination", {"product": "CCO", "reactants": ["CC", "O"]}
+        )
+        assert result["is_hallucination"] is True
+
+
+class TestRunPython:
+    def test_absent_in_structured_backend(self) -> None:
+        registry = build_tool_registry(tool_backend="structured")
+        assert "run_python" not in registry.names
+
+    def test_present_and_executes_in_sandbox_backend(self) -> None:
+        registry = build_tool_registry(
+            tool_backend="sandbox", sandbox=SubprocessSandbox()
+        )
+        assert "run_python" in registry.names
+        result = registry.execute("run_python", {"code": "print(6 * 7)"})
+        assert result["ok"] is True
+        assert "42" in result["stdout"]
+
+
+class TestDispatcher:
+    def test_unknown_tool_returns_error(self) -> None:
+        registry = build_tool_registry()
+        result = registry.execute("does_not_exist", {})
+        assert "error" in result
+
+    def test_executor_exception_is_captured(self) -> None:
+        # Missing required argument raises inside the executor; the dispatcher
+        # must turn that into an error dict rather than propagating.
+        registry = build_tool_registry()
+        result = registry.execute("validate_smiles", {})
+        assert "error" in result
+
+
+class TestSchemas:
+    def test_schemas_use_openai_function_format(self) -> None:
+        registry = build_tool_registry(
+            hallucination_checker=keep_all,
+            tool_backend="sandbox",
+            sandbox=SubprocessSandbox(),
+        )
+        assert registry.schemas
+        for schema in registry.schemas:
+            assert schema["type"] == "function"
+            assert "name" in schema["function"]
+            assert "parameters" in schema["function"]
+        schema_names = {s["function"]["name"] for s in registry.schemas}
+        assert schema_names == set(registry.names)

--- a/deepretro/tests/test_autosolve.py
+++ b/deepretro/tests/test_autosolve.py
@@ -1,0 +1,845 @@
+"""Tests for the AutoSolver retrosynthesis pipeline."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+import pytest
+
+from deepretro.algorithms.autosolve import (
+    AutoSolver,
+    reaction_tree,
+    unsolved_leaf,
+)
+from deepretro.utils.utils_molecule import canonicalize
+
+ASPIRIN = "CC(=O)Oc1ccccc1C(=O)O"
+SALICYLIC_ACID = "OC(=O)c1ccccc1O"
+ACETIC_ANHYDRIDE = "CC(=O)OC(C)=O"
+PARACETAMOL = "CC(=O)Nc1ccc(O)cc1"
+PARA_AMINOPHENOL = "Nc1ccc(O)cc1"
+IBUPROFEN = "CC(C)Cc1ccc(cc1)C(C)C(=O)O"
+CAFFEINE = "Cn1c(=O)c2c(ncn2C)n(C)c1=O"
+ACETIC_ACID = "CC(=O)O"
+
+
+def solved_route(smiles: str) -> dict[str, Any]:
+    """Minimal in-stock route node for a solved molecule."""
+    return {
+        "type": "mol",
+        "smiles": smiles,
+        "is_chemical": True,
+        "in_stock": True,
+    }
+
+
+def az_always_fails(smiles: str, az_model: str) -> tuple[bool, list[Any]]:
+    """AZ runner that never solves any molecule."""
+    return False, []
+
+
+def az_solves_all(smiles: str, az_model: str) -> tuple[bool, list[Any]]:
+    """AZ runner that solves every molecule."""
+    return True, [solved_route(smiles)]
+
+
+class SelectiveAzRunner:
+    """AZ runner that solves only configured canonical molecules."""
+
+    def __init__(self, solvable: set[str]) -> None:
+        self.solvable = {canonicalize(smiles) for smiles in solvable}
+
+    def __call__(self, smiles: str, az_model: str) -> tuple[bool, list[Any]]:
+        if canonicalize(smiles) in self.solvable:
+            return True, [solved_route(smiles)]
+        return False, []
+
+
+class RecordingAzRunner:
+    """AZ runner that records calls and never solves."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def __call__(self, smiles: str, az_model: str) -> tuple[bool, list[Any]]:
+        self.calls.append(smiles)
+        return False, []
+
+
+class RecordingLlmRunner:
+    """LLM runner that records calls and returns no pathways."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def __call__(
+        self, molecule: str, **kwargs: Any
+    ) -> tuple[list[list[str]], list[str], list[float]]:
+        self.calls.append(molecule)
+        return [], [], []
+
+
+class CapturingLlmRunner:
+    """LLM runner that records call arguments and returns a solvable pathway."""
+
+    def __init__(self) -> None:
+        self.captured: dict[str, Any] = {}
+
+    def __call__(
+        self, molecule: str, **kwargs: Any
+    ) -> tuple[list[list[str]], list[str], list[float]]:
+        self.captured["molecule"] = molecule
+        self.captured.update(kwargs)
+        return [[SALICYLIC_ACID]], ["hydrolysis"], [0.7]
+
+
+def llm_returns_nothing(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """LLM runner that returns no pathways."""
+    return [], [], []
+
+
+def llm_proposes_hydrolysis(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """LLM runner proposing aspirin hydrolysis."""
+    return [[SALICYLIC_ACID, ACETIC_ACID]], ["hydrolysis"], [0.9]
+
+
+def llm_returns_aspirin_self_reference(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """LLM runner returning aspirin in a non-canonical equivalent form."""
+    return [["OC(=O)c1ccccc1OC(=O)C"]], ["self-reference"], [0.5]
+
+
+def llm_two_pathways(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """LLM runner where only the second pathway can fully solve."""
+    if canonicalize(molecule) == canonicalize(ASPIRIN):
+        return [[IBUPROFEN], [ACETIC_ACID]], ["wrong", "right"], [0.3, 0.8]
+    return [], [], []
+
+
+def llm_unsolvable_ibuprofen(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """LLM runner proposing an unsolved ibuprofen branch for aspirin."""
+    if canonicalize(molecule) == canonicalize(ASPIRIN):
+        return [[IBUPROFEN]], ["try ibuprofen"], [0.4]
+    return [], [], []
+
+
+def llm_proposes_paracetamol_acetylation(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """LLM runner proposing paracetamol acetylation."""
+    return [[PARA_AMINOPHENOL, ACETIC_ANHYDRIDE]], ["acetylation"], [0.8]
+
+
+def llm_empty_then_acetic_acid(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """LLM runner returning an empty pathway before a valid pathway."""
+    return [[], [ACETIC_ACID]], ["empty", "real"], [0.1, 0.9]
+
+
+def llm_empty_then_hydrolysis(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """LLM runner returning an empty pathway before aspirin hydrolysis."""
+    return [[], [SALICYLIC_ACID, ACETIC_ACID]], ["empty", "hydrolysis"], [0.1, 0.9]
+
+
+def llm_stub_reduction(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """LLM runner returning one reduction pathway."""
+    return [["CCO"]], ["reduce"], [0.8]
+
+
+def aspirin_hydrolysis_tree() -> dict[str, Any]:
+    """One-step route: aspirin -> salicylic acid + acetic anhydride."""
+    return reaction_tree(
+        ASPIRIN,
+        [unsolved_leaf(SALICYLIC_ACID), unsolved_leaf(ACETIC_ANHYDRIDE)],
+        [0.9],
+    )
+
+
+class TestUnsolvedLeaf:
+    def test_aspirin(self) -> None:
+        """Unsolved leaf for aspirin has the expected mol-node fields."""
+        node = unsolved_leaf(ASPIRIN)
+        assert node["smiles"] == ASPIRIN
+        assert node["type"] == "mol"
+        assert node["is_chemical"] is True
+        assert node["in_stock"] is False
+        assert node["children"] == []
+
+    def test_caffeine(self) -> None:
+        """Unsolved leaf for caffeine is marked not in stock."""
+        node = unsolved_leaf(CAFFEINE)
+        assert node["smiles"] == CAFFEINE
+        assert node["in_stock"] is False
+
+
+class TestReactionTree:
+    def test_aspirin_hydrolysis(self) -> None:
+        """Reaction tree nests children and stores confidence as policy_probability."""
+        children = [unsolved_leaf(SALICYLIC_ACID), unsolved_leaf(ACETIC_ANHYDRIDE)]
+        tree = reaction_tree(ASPIRIN, children, [0.85])
+        assert tree["smiles"] == ASPIRIN
+        rxn = tree["children"][0]
+        assert rxn["type"] == "reaction"
+        assert rxn["metadata"]["policy_probability"] == pytest.approx(0.85)
+        assert rxn["children"] == children
+
+    def test_empty_confidence(self) -> None:
+        """Empty confidence defaults policy_probability to 0.0."""
+        tree = reaction_tree(ASPIRIN, [], [])
+        assert tree["children"][0]["metadata"]["policy_probability"] == 0.0
+
+
+class TestConstructor:
+    def test_preserves_options(self) -> None:
+        """Constructor stores all explicitly provided options."""
+        solver = AutoSolver(
+            llm="anthropic/claude-sonnet-4-6",
+            az_model="USPTO",
+            stability_check=False,
+            hallucination_mode="none",
+            max_depth=3,
+            enable_thinking=False,
+            max_output_tokens=128,
+            metadata_model="anthropic/claude-sonnet-4-6",
+        )
+        assert solver.llm == "anthropic/claude-sonnet-4-6"
+        assert solver.az_model == "USPTO"
+        assert solver.stability_check is False
+        assert solver.hallucination_mode == "none"
+        assert solver.hallucination_checker is None
+        assert solver.max_depth == 3
+        assert solver.enable_thinking is False
+        assert solver.max_output_tokens == 128
+        assert solver.metadata_model == "anthropic/claude-sonnet-4-6"
+
+    def test_defaults(self) -> None:
+        """Constructor applies the documented default options."""
+        solver = AutoSolver(hallucination_mode="none")
+        assert solver.llm == "anthropic/claude-sonnet-4-6"
+        assert solver.az_model == "Pistachio_100+"
+        assert solver.stability_check is True
+        assert solver.max_depth == 50
+        assert solver.enable_thinking is True
+        assert solver.max_output_tokens is None
+        assert solver.metadata_model == "anthropic/claude-sonnet-4-6"
+
+    def test_normalizes_hallucination_mode(self) -> None:
+        """hallucination_mode is lower-cased on construction."""
+        solver = AutoSolver(hallucination_mode="NONE")
+        assert solver.hallucination_mode == "none"
+
+    def test_rejects_negative_max_depth(self) -> None:
+        """A negative max_depth raises ValueError."""
+        with pytest.raises(ValueError, match="max_depth"):
+            AutoSolver(hallucination_mode="none", max_depth=-1)
+
+
+class TestSolve:
+    def test_az_success_returns_route(self) -> None:
+        """AZ success returns the AZ route marked solved."""
+        solver = AutoSolver(az_runner=az_solves_all, hallucination_mode="none")
+        route, solved = solver.solve(ASPIRIN)
+
+        assert solved is True
+        assert route["smiles"] == ASPIRIN
+        assert route["in_stock"] is True
+
+    def test_az_success_skips_llm(self) -> None:
+        """LLM fallback is skipped when AZ already solves the target."""
+        llm_runner = RecordingLlmRunner()
+        solver = AutoSolver(
+            az_runner=az_solves_all,
+            llm_runner=llm_runner,
+            hallucination_mode="none",
+        )
+        solver.solve(ASPIRIN)
+        assert llm_runner.calls == []
+
+    def test_llm_fallback_with_solvable_precursors(self) -> None:
+        """LLM fallback solves when its precursors are AZ-solvable."""
+        solver = AutoSolver(
+            az_runner=SelectiveAzRunner({SALICYLIC_ACID, ACETIC_ACID}),
+            llm_runner=llm_proposes_hydrolysis,
+            hallucination_mode="none",
+        )
+        route, solved = solver.solve(ASPIRIN)
+
+        assert solved is True
+        assert len(route["children"][0]["children"]) == 2
+
+    def test_cycle_detection_with_non_canonical_form(self) -> None:
+        """A precursor equal to the target (non-canonical) is detected as a cycle."""
+        solver = AutoSolver(
+            az_runner=az_always_fails,
+            llm_runner=llm_returns_aspirin_self_reference,
+            hallucination_mode="none",
+        )
+        route, solved = solver.solve(ASPIRIN)
+
+        assert solved is False
+        child = route["children"][0]["children"][0]
+        assert canonicalize(child["smiles"]) == canonicalize(ASPIRIN)
+
+    def test_max_depth_zero_skips_az(self) -> None:
+        """max_depth=0 returns an unsolved leaf without calling AZ."""
+        az_runner = RecordingAzRunner()
+        solver = AutoSolver(az_runner=az_runner, hallucination_mode="none", max_depth=0)
+        route, solved = solver.solve(ASPIRIN)
+
+        assert (route, solved) == (unsolved_leaf(ASPIRIN), False)
+        assert az_runner.calls == []
+
+    def test_empty_input_skips_az_and_llm(self) -> None:
+        """Blank input short-circuits before AZ and LLM are called."""
+        az_runner = RecordingAzRunner()
+        llm_runner = RecordingLlmRunner()
+        solver = AutoSolver(
+            az_runner=az_runner,
+            llm_runner=llm_runner,
+            hallucination_mode="none",
+        )
+        route, solved = solver.solve("   ")
+
+        assert (route, solved) == (unsolved_leaf(""), False)
+        assert az_runner.calls == []
+        assert llm_runner.calls == []
+
+    def test_no_pathways_returns_unsolved(self) -> None:
+        """No LLM pathways yields an unsolved leaf."""
+        solver = AutoSolver(
+            az_runner=az_always_fails,
+            llm_runner=llm_returns_nothing,
+            hallucination_mode="none",
+        )
+        route, solved = solver.solve(CAFFEINE)
+
+        assert solved is False
+        assert route == unsolved_leaf(CAFFEINE)
+
+    def test_selects_first_fully_solved_pathway_with_correct_confidence(self) -> None:
+        """The first fully solved pathway is chosen with its own confidence."""
+        solver = AutoSolver(
+            az_runner=SelectiveAzRunner({ACETIC_ACID}),
+            llm_runner=llm_two_pathways,
+            hallucination_mode="none",
+        )
+        route, solved = solver.solve(ASPIRIN)
+
+        assert solved is True
+        assert route["children"][0]["children"][0]["smiles"] == ACETIC_ACID
+        assert route["children"][0]["metadata"]["policy_probability"] == pytest.approx(
+            0.8
+        )
+
+    def test_partial_result_when_nothing_fully_solves(self) -> None:
+        """When nothing fully solves, the first attempted pathway is returned unsolved."""
+        solver = AutoSolver(
+            az_runner=az_always_fails,
+            llm_runner=llm_unsolvable_ibuprofen,
+            hallucination_mode="none",
+        )
+        route, solved = solver.solve(ASPIRIN)
+
+        assert solved is False
+        assert route["children"][0]["children"] == [unsolved_leaf(IBUPROFEN)]
+
+    def test_multi_reactant_pathway(self) -> None:
+        """A multi-reactant pathway solves when all reactants are AZ-solvable."""
+        solver = AutoSolver(
+            az_runner=SelectiveAzRunner({PARA_AMINOPHENOL, ACETIC_ANHYDRIDE}),
+            llm_runner=llm_proposes_paracetamol_acetylation,
+            hallucination_mode="none",
+        )
+        route, solved = solver.solve(PARACETAMOL)
+
+        assert solved is True
+        assert len(route["children"][0]["children"]) == 2
+
+    def test_empty_pathway_is_not_treated_as_solved(self) -> None:
+        """An empty pathway is skipped in favour of the next candidate."""
+        solver = AutoSolver(
+            az_runner=SelectiveAzRunner({ACETIC_ACID}),
+            llm_runner=llm_empty_then_acetic_acid,
+            hallucination_mode="none",
+        )
+        route, solved = solver.solve(ASPIRIN)
+
+        assert solved is True
+        assert route["children"][0]["children"][0]["smiles"] == ACETIC_ACID
+        assert route["children"][0]["metadata"]["policy_probability"] == pytest.approx(
+            0.9
+        )
+
+    def test_llm_runner_receives_correct_kwargs(self) -> None:
+        """Solver forwards its configured options to the LLM runner."""
+        llm_runner = CapturingLlmRunner()
+        solver = AutoSolver(
+            llm="anthropic/claude-sonnet-4-6",
+            az_runner=SelectiveAzRunner({SALICYLIC_ACID}),
+            llm_runner=llm_runner,
+            stability_check=False,
+            hallucination_mode="heuristic",
+            enable_thinking=False,
+            max_output_tokens=64,
+        )
+        solver.solve(ASPIRIN)
+
+        captured = llm_runner.captured
+        assert captured["molecule"] == ASPIRIN
+        assert captured["model"] == "anthropic/claude-sonnet-4-6"
+        assert captured["stability_check"] is False
+        # run_llm owns hallucination filtering (via filter_with_checker), so it
+        # always disables llm_pipeline's internal pass to avoid a double filter.
+        assert captured["hallucination_check"] is False
+        assert captured["enable_thinking"] is False
+        assert captured["max_output_tokens"] == 64
+
+
+class TestRunLlm:
+    def test_returns_pathways_from_injected_runner(self) -> None:
+        """run_llm returns the injected runner's pathways, explanations, and confidence."""
+        solver = AutoSolver(llm_runner=llm_stub_reduction, hallucination_mode="none")
+        pathways, explanations, confidence = solver.run_llm(ASPIRIN)
+
+        assert pathways == [["CCO"]]
+        assert explanations == ["reduce"]
+        assert confidence == [0.8]
+
+    def test_empty_runner(self) -> None:
+        """run_llm returns empty results when the runner yields nothing."""
+        solver = AutoSolver(llm_runner=llm_returns_nothing, hallucination_mode="none")
+        pathways, explanations, confidence = solver.run_llm(ASPIRIN)
+
+        assert pathways == []
+        assert explanations == []
+        assert confidence == []
+
+
+class TestSingleStep:
+    def test_az_success(self) -> None:
+        """single_step returns the AZ route when AZ solves the target."""
+        solver = AutoSolver(az_runner=az_solves_all, hallucination_mode="none")
+        route, solved = solver.single_step(ASPIRIN)
+
+        assert solved is True
+        assert route["smiles"] == ASPIRIN
+
+    def test_llm_builds_one_level_tree(self) -> None:
+        """single_step builds a one-level tree of unsolved precursors."""
+        solver = AutoSolver(
+            az_runner=az_always_fails,
+            llm_runner=llm_proposes_hydrolysis,
+            hallucination_mode="none",
+        )
+        route, solved = solver.single_step(ASPIRIN)
+
+        assert solved is False
+        children = route["children"][0]["children"]
+        assert children[0] == unsolved_leaf(SALICYLIC_ACID)
+        assert children[1] == unsolved_leaf(ACETIC_ACID)
+
+    def test_empty_first_pathway_uses_first_non_empty_candidate(self) -> None:
+        """single_step skips an empty pathway and uses the next candidate."""
+        solver = AutoSolver(
+            az_runner=az_always_fails,
+            llm_runner=llm_empty_then_hydrolysis,
+            hallucination_mode="none",
+        )
+        route, solved = solver.single_step(ASPIRIN)
+
+        assert solved is False
+        assert route["children"][0]["metadata"]["policy_probability"] == pytest.approx(
+            0.9
+        )
+        assert route["children"][0]["children"] == [
+            unsolved_leaf(SALICYLIC_ACID),
+            unsolved_leaf(ACETIC_ACID),
+        ]
+
+    def test_no_pathways(self) -> None:
+        """single_step returns an unsolved leaf when no pathways are produced."""
+        solver = AutoSolver(
+            az_runner=az_always_fails,
+            llm_runner=llm_returns_nothing,
+            hallucination_mode="none",
+        )
+        route, solved = solver.single_step(CAFFEINE)
+
+        assert solved is False
+        assert route == unsolved_leaf(CAFFEINE)
+
+
+class TestParse:
+    def test_aspirin_hydrolysis_product(self) -> None:
+        """parse exposes the product SMILES and the solved flag."""
+        solver = AutoSolver(hallucination_mode="none")
+        result = solver.parse(aspirin_hydrolysis_tree(), solved=True)
+
+        assert result["solved"] is True
+        assert len(result["steps"]) >= 1
+        assert result["steps"][0]["products"][0]["smiles"] == ASPIRIN
+
+    def test_solved_false_propagates(self) -> None:
+        """parse propagates solved=False into the output."""
+        solver = AutoSolver(hallucination_mode="none")
+        tree = reaction_tree(ASPIRIN, [unsolved_leaf(SALICYLIC_ACID)], [0.5])
+        result = solver.parse(tree, solved=False)
+
+        assert result["solved"] is False
+
+    def test_two_step_route_dependencies(self) -> None:
+        """parse emits multiple steps with dependency links for nested routes."""
+        inner = reaction_tree(
+            PARA_AMINOPHENOL,
+            [unsolved_leaf("Nc1ccccc1"), unsolved_leaf("O")],
+            [0.6],
+        )
+        outer = reaction_tree(
+            PARACETAMOL,
+            [inner, unsolved_leaf(ACETIC_ANHYDRIDE)],
+            [0.8],
+        )
+        solver = AutoSolver(hallucination_mode="none")
+        result = solver.parse(outer, solved=False)
+
+        assert len(result["steps"]) >= 2
+        assert any(len(v) > 0 for v in result["dependencies"].values())
+
+
+HAS_LITELLM = importlib.util.find_spec("litellm") is not None
+
+
+@pytest.mark.skipif(
+    not HAS_LITELLM, reason="litellm required for metadata recommendation"
+)
+class TestAddMetadata:
+    def test_enriches_step(
+        self,
+        spy_reagent_recommender,
+        spy_conditions_recommender,
+        spy_literature_recommender,
+        recommender_calls,
+    ) -> None:
+        """add_metadata fills reagents and conditions from the recommenders."""
+        solver = AutoSolver(
+            hallucination_mode="none", metadata_model="anthropic/claude-sonnet-4-6"
+        )
+        parsed = solver.parse(aspirin_hydrolysis_tree(), solved=True)
+        result = solver.add_metadata(
+            parsed,
+            reagent_recommender=spy_reagent_recommender,
+            conditions_recommender=spy_conditions_recommender,
+            literature_recommender=spy_literature_recommender,
+        )
+
+        assert any("reagent" in c for c in recommender_calls)
+        step = result["steps"][0]
+        assert len(step["reagents"]) > 0
+        assert step["conditions"]["temperature"] == "25 C"
+
+    def test_skips_step_when_reagent_fails(
+        self,
+        failing_reagent_recommender,
+    ) -> None:
+        """A failing reagent recommender leaves the step unchanged."""
+        solver = AutoSolver(hallucination_mode="none")
+        parsed = solver.parse(aspirin_hydrolysis_tree(), solved=True)
+        original_reagents = list(parsed["steps"][0]["reagents"])
+
+        result = solver.add_metadata(
+            parsed,
+            reagent_recommender=failing_reagent_recommender,
+        )
+
+        assert result["steps"][0]["reagents"] == original_reagents
+
+    def test_forwards_metadata_model(
+        self,
+        spy_reagent_recommender,
+        spy_conditions_recommender,
+        spy_literature_recommender,
+        recommender_calls,
+    ) -> None:
+        """The configured metadata_model is forwarded to the recommenders."""
+        solver = AutoSolver(
+            hallucination_mode="none",
+            metadata_model="anthropic/claude-sonnet-4-6",
+        )
+        parsed = solver.parse(aspirin_hydrolysis_tree(), solved=True)
+        solver.add_metadata(
+            parsed,
+            reagent_recommender=spy_reagent_recommender,
+            conditions_recommender=spy_conditions_recommender,
+            literature_recommender=spy_literature_recommender,
+        )
+
+        assert all("anthropic/claude-sonnet-4-6" in c for c in recommender_calls)
+
+    def test_skips_step_with_no_reactants(
+        self,
+        spy_reagent_recommender,
+        recommender_calls,
+    ) -> None:
+        """Steps without reactants are skipped (no recommender calls)."""
+        parsed: dict[str, Any] = {
+            "steps": [
+                {
+                    "step": "1",
+                    "reactants": [],
+                    "reagents": [],
+                    "products": [{"smiles": ASPIRIN, "product_metadata": {}}],
+                    "conditions": [],
+                    "reactionmetrics": [
+                        {"scalabilityindex": 0, "closestliterature": ""}
+                    ],
+                }
+            ],
+            "dependencies": {"1": []},
+            "solved": True,
+        }
+        solver = AutoSolver(hallucination_mode="none")
+        solver.add_metadata(parsed, reagent_recommender=spy_reagent_recommender)
+
+        assert recommender_calls == []
+
+    def test_adds_missing_reactionmetrics_for_enriched_step(
+        self,
+        spy_reagent_recommender,
+        spy_conditions_recommender,
+        spy_literature_recommender,
+    ) -> None:
+        """Missing reactionmetrics are created and closestliterature holds the DOI string."""
+        parsed = {
+            "steps": [
+                {
+                    "step": "1",
+                    "reactants": [{"smiles": SALICYLIC_ACID}],
+                    "reagents": [],
+                    "products": [{"smiles": ASPIRIN, "product_metadata": {}}],
+                    "conditions": {},
+                    "reactionmetrics": [],
+                }
+            ],
+            "dependencies": {"1": []},
+            "solved": True,
+        }
+        solver = AutoSolver(hallucination_mode="none")
+
+        result = solver.add_metadata(
+            parsed,
+            reagent_recommender=spy_reagent_recommender,
+            conditions_recommender=spy_conditions_recommender,
+            literature_recommender=spy_literature_recommender,
+        )
+
+        metrics = result["steps"][0]["reactionmetrics"]
+        assert metrics[0]["closestliterature"] == "10.1000/example"
+
+
+class TestAutosolve:
+    def test_returns_parsed_result_for_az_solved_target(self) -> None:
+        """autosolve returns a parsed, solved result for an AZ-solved target."""
+        solver = AutoSolver(az_runner=az_solves_all, hallucination_mode="none")
+        result = solver.autosolve(ASPIRIN)
+
+        assert result["solved"] is True
+        assert result["steps"] == []
+        assert result["dependencies"] == {}
+
+
+# ---------------------------------------------------------------------------
+# New behaviour: solve_mode / tool_backend flags, orchestrator guard,
+# AZ-exception handling, solve_multiple, and the agent-mode safety net.
+# ---------------------------------------------------------------------------
+
+INVALID_SMILES = "not_a_smiles!!!"
+# Alkanes that are not substructures of aspirin, so they survive validity_check
+# (salicylic/acetic acid do not — aspirin is acetylsalicylic acid).
+OCTANE = "CCCCCCCC"
+DECANE = "CCCCCCCCCC"
+
+
+def az_raises_missing_models(smiles: str, az_model: str) -> tuple[bool, list[Any]]:
+    """AZ runner that raises as if its model files were missing."""
+    raise FileNotFoundError("config.yml not found")
+
+
+def llm_three_single_reactant_pathways(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """Three ranked single-reactant pathways for aspirin only (empty otherwise)."""
+    if canonicalize(molecule) == canonicalize(ASPIRIN):
+        return (
+            [[SALICYLIC_ACID], [ACETIC_ACID], [IBUPROFEN]],
+            ["a", "b", "c"],
+            [0.9, 0.8, 0.7],
+        )
+    return [], [], []
+
+
+def llm_two_pathways_sharing_reactant(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """Two aspirin pathways sharing an AZ-solvable reactant (visited-independence)."""
+    if canonicalize(molecule) == canonicalize(ASPIRIN):
+        return (
+            [[SALICYLIC_ACID], [SALICYLIC_ACID, ACETIC_ACID]],
+            ["one", "two"],
+            [0.9, 0.8],
+        )
+    return [], [], []
+
+
+def agent_returns_invalid_and_valid(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """Agent runner whose first pathway contains an invalid SMILES."""
+    return (
+        [[INVALID_SMILES], [OCTANE]],
+        ["bogus", "valid"],
+        [0.9, 0.8],
+    )
+
+
+def agent_proposes_two_alkanes(
+    molecule: str, **kwargs: Any
+) -> tuple[list[list[str]], list[str], list[float]]:
+    """Agent runner proposing two AZ-solvable, non-substructure reactants."""
+    if canonicalize(molecule) == canonicalize(ASPIRIN):
+        return [[OCTANE, DECANE]], ["split"], [0.8]
+    return [], [], []
+
+
+class TestSolveModeFlags:
+    def test_defaults(self) -> None:
+        """solve_mode and tool_backend default to pipeline/structured."""
+        solver = AutoSolver(hallucination_mode="none")
+        assert solver.solve_mode == "pipeline"
+        assert solver.tool_backend == "structured"
+
+    def test_rejects_unknown_solve_mode(self) -> None:
+        with pytest.raises(ValueError, match="solve_mode"):
+            AutoSolver(hallucination_mode="none", solve_mode="bogus")
+
+    def test_rejects_unknown_tool_backend(self) -> None:
+        with pytest.raises(ValueError, match="tool_backend"):
+            AutoSolver(hallucination_mode="none", tool_backend="bogus")
+
+
+class TestOrchestratorGuard:
+    def test_solve_raises_not_implemented(self) -> None:
+        solver = AutoSolver(hallucination_mode="none", solve_mode="orchestrator")
+        with pytest.raises(NotImplementedError, match="orchestrator"):
+            solver.solve(ASPIRIN)
+
+    def test_solve_multiple_raises_not_implemented(self) -> None:
+        solver = AutoSolver(hallucination_mode="none", solve_mode="orchestrator")
+        with pytest.raises(NotImplementedError, match="orchestrator"):
+            solver.solve_multiple(ASPIRIN)
+
+    def test_single_step_raises_not_implemented(self) -> None:
+        solver = AutoSolver(hallucination_mode="none", solve_mode="orchestrator")
+        with pytest.raises(NotImplementedError, match="orchestrator"):
+            solver.single_step(ASPIRIN)
+
+
+class TestAzExceptions:
+    def test_az_exception_degrades_to_unsolved_leaf(self) -> None:
+        """A raising AZ runner is caught and the node becomes an unsolved leaf."""
+        solver = AutoSolver(
+            az_runner=az_raises_missing_models, hallucination_mode="none"
+        )
+        route, solved = solver.solve(CAFFEINE)
+
+        assert solved is False
+        assert route == unsolved_leaf(CAFFEINE)
+
+
+class TestSolveMultiple:
+    def test_az_solved_returns_single_route(self) -> None:
+        """When AZ solves the target, solve_multiple returns one solved route."""
+        solver = AutoSolver(az_runner=az_solves_all, hallucination_mode="none")
+        results = solver.solve_multiple(ASPIRIN, k=3)
+
+        assert len(results) == 1
+        route, solved = results[0]
+        assert solved is True
+        assert route["smiles"] == ASPIRIN
+
+    def test_top_k_candidate_routes(self) -> None:
+        """solve_multiple returns up to k routes, one per candidate pathway."""
+        solver = AutoSolver(
+            az_runner=SelectiveAzRunner({SALICYLIC_ACID, ACETIC_ACID}),
+            llm_runner=llm_three_single_reactant_pathways,
+            hallucination_mode="none",
+        )
+        results = solver.solve_multiple(ASPIRIN, k=3)
+
+        assert len(results) == 3
+        assert [solved for _, solved in results] == [True, True, False]
+        assert results[0][0]["children"][0]["children"][0]["smiles"] == SALICYLIC_ACID
+        assert results[2][0]["children"][0]["children"][0]["smiles"] == IBUPROFEN
+
+    def test_respects_k_limit(self) -> None:
+        solver = AutoSolver(
+            az_runner=SelectiveAzRunner({SALICYLIC_ACID, ACETIC_ACID}),
+            llm_runner=llm_three_single_reactant_pathways,
+            hallucination_mode="none",
+        )
+        assert len(solver.solve_multiple(ASPIRIN, k=2)) == 2
+
+    def test_routes_use_independent_visited_sets(self) -> None:
+        """A reactant shared across candidate routes solves in every route."""
+        solver = AutoSolver(
+            az_runner=SelectiveAzRunner({SALICYLIC_ACID, ACETIC_ACID}),
+            llm_runner=llm_two_pathways_sharing_reactant,
+            hallucination_mode="none",
+        )
+        results = solver.solve_multiple(ASPIRIN, k=2)
+
+        assert [solved for _, solved in results] == [True, True]
+
+
+class TestAgentModeSafetyNet:
+    def test_agent_pathways_pass_through_validity_filter(self) -> None:
+        """single_step_agent applies the validity filter the agent could bypass."""
+        solver = AutoSolver(
+            solve_mode="single_step_agent",
+            agent_runner=agent_returns_invalid_and_valid,
+            hallucination_mode="none",
+            stability_check=False,
+        )
+        pathways, explanations, confidence = solver.run_llm(ASPIRIN)
+
+        assert pathways == [[OCTANE]]
+        assert explanations == ["valid"]
+        assert confidence == [0.8]
+
+    def test_agent_runner_used_for_solve(self) -> None:
+        """In agent mode, solve drives recursion off the agent runner output."""
+        solver = AutoSolver(
+            solve_mode="single_step_agent",
+            az_runner=SelectiveAzRunner({OCTANE, DECANE}),
+            agent_runner=agent_proposes_two_alkanes,
+            hallucination_mode="none",
+            stability_check=False,
+        )
+        route, solved = solver.solve(ASPIRIN)
+
+        assert solved is True
+        assert len(route["children"][0]["children"]) == 2

--- a/deepretro/tests/test_batch.py
+++ b/deepretro/tests/test_batch.py
@@ -1,0 +1,118 @@
+"""Tests for the batch retrosynthesis runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from deepretro import batch
+
+
+class FakeResponse:
+    """Minimal stand-in for a requests.Response."""
+
+    def __init__(self, content: bytes, status: int = 200) -> None:
+        self.content = content
+        self.status = status
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise RuntimeError(f"HTTP {self.status}")
+
+
+class FakeSolver:
+    """AutoSolver-shaped double returning two routes for any molecule."""
+
+    def solve_multiple(self, smiles: str, k: int = 3) -> list[tuple[dict, bool]]:
+        return [
+            ({"type": "mol", "smiles": smiles, "children": []}, True),
+            ({"type": "mol", "smiles": smiles, "children": []}, False),
+        ][:k]
+
+    def parse(self, route: dict, *, solved: bool) -> dict[str, Any]:
+        return {"steps": [], "dependencies": {}, "solved": solved}
+
+    def add_metadata(self, parsed: dict[str, Any]) -> dict[str, Any]:
+        parsed["enriched"] = True
+        return parsed
+
+
+def test_read_molecules_skips_blanks_and_comments(tmp_path: Path) -> None:
+    path = tmp_path / "mols.txt"
+    path.write_text("CCO\n\n# a comment\n  CC(=O)O  \n")
+    assert batch.read_molecules(str(path)) == ["CCO", "CC(=O)O"]
+
+
+def test_slugify_is_filesystem_safe_and_deterministic() -> None:
+    slug = batch.slugify_molecule("CC(=O)Oc1ccccc1C(=O)O")
+    assert "/" not in slug and "(" not in slug and ")" not in slug
+    assert slug == batch.slugify_molecule("CC(=O)Oc1ccccc1C(=O)O")
+
+
+def test_slugify_distinguishes_different_molecules() -> None:
+    assert batch.slugify_molecule("CCO") != batch.slugify_molecule("CCN")
+
+
+def test_download_sheet_csv_writes_content(tmp_path: Path) -> None:
+    dest = tmp_path / "data.csv"
+
+    def fake_get(url: str, timeout: float | None = None) -> FakeResponse:
+        return FakeResponse(b"product,reactants,label\nCCO,CC,0\n")
+
+    batch.download_sheet_csv("http://sheet", str(dest), http_get=fake_get)
+    assert dest.read_bytes().startswith(b"product,reactants,label")
+
+
+def test_download_sheet_csv_raises_on_http_error(tmp_path: Path) -> None:
+    def fake_get(url: str, timeout: float | None = None) -> FakeResponse:
+        return FakeResponse(b"", status=404)
+
+    with pytest.raises(RuntimeError):
+        batch.download_sheet_csv(
+            "http://sheet", str(tmp_path / "x.csv"), http_get=fake_get
+        )
+
+
+def test_solve_molecule_attaches_target_to_each_pathway() -> None:
+    pathways = batch.solve_molecule(FakeSolver(), "CCO", top_k=3)
+    assert len(pathways) == 2
+    assert all(p["target"] == "CCO" for p in pathways)
+    assert all(p["enriched"] is True for p in pathways)
+
+
+def test_run_batch_writes_pathway_files(tmp_path: Path) -> None:
+    def solve(smiles: str) -> list[dict[str, Any]]:
+        return [{"target": smiles, "solved": True}, {"target": smiles, "solved": False}]
+
+    batch.run_batch(
+        ["CCO"], str(tmp_path), timestamp="2026-07-01_00-00-00", solve=solve
+    )
+    mol_dir = tmp_path / "2026-07-01_00-00-00" / batch.slugify_molecule("CCO")
+    assert (mol_dir / "pathway_1.json").exists()
+    assert (mol_dir / "pathway_2.json").exists()
+    payload = json.loads((mol_dir / "pathway_1.json").read_text())
+    assert payload["target"] == "CCO"
+
+
+def test_run_batch_writes_error_json_on_failure(tmp_path: Path) -> None:
+    def solve(smiles: str) -> list[dict[str, Any]]:
+        raise RuntimeError("solver exploded")
+
+    batch.run_batch(
+        ["CCO"], str(tmp_path), timestamp="2026-07-01_00-00-00", solve=solve
+    )
+    error_file = (
+        tmp_path / "2026-07-01_00-00-00" / batch.slugify_molecule("CCO") / "error.json"
+    )
+    assert error_file.exists()
+    assert "solver exploded" in error_file.read_text()
+
+
+def test_train_hallucination_checker_skips_without_label_column(tmp_path: Path) -> None:
+    csv_path = tmp_path / "unlabeled.csv"
+    csv_path.write_text("product,reactants\nCCO,CC\n")
+    result = batch.train_hallucination_checker(str(csv_path), str(tmp_path / "model"))
+    assert result is None

--- a/deepretro/tests/test_hallucination_helpers.py
+++ b/deepretro/tests/test_hallucination_helpers.py
@@ -121,3 +121,67 @@ def test_inline_classifier_matches_predict_probability_contract() -> None:
 
     assert labels.shape == (1,)
     assert probabilities.shape == (1,)
+
+
+def _drop_second_checker(product: str, pathways: list) -> tuple[int, list]:
+    """Order-preserving checker double: keep every pathway except index 1."""
+    del product
+    kept = [pathway for i, pathway in enumerate(pathways) if i != 1]
+    if kept:
+        return 200, kept
+    return 400, []
+
+
+class TestFilterWithChecker:
+    """Tests for ``hallucination_helpers.filter_with_checker`` realignment."""
+
+    def test_none_checker_passes_everything_through(self) -> None:
+        from deepretro.models.hallucination_helpers import filter_with_checker
+
+        pathways = [["CC"], ["O"]]
+        result = filter_with_checker(
+            "CCO", pathways, ["a", "b"], [0.1, 0.2], None
+        )
+        assert result == (pathways, ["a", "b"], [0.1, 0.2])
+
+    def test_kept_subset_keeps_aligned_explanations_and_confidence(self) -> None:
+        from deepretro.models.hallucination_helpers import filter_with_checker
+
+        pathways = [["A"], ["B"], ["C"]]
+        kept, expl, conf = filter_with_checker(
+            "P",
+            pathways,
+            ["expl_a", "expl_b", "expl_c"],
+            [0.1, 0.2, 0.3],
+            _drop_second_checker,
+        )
+        assert kept == [["A"], ["C"]]
+        assert expl == ["expl_a", "expl_c"]
+        assert conf == [0.1, 0.3]
+
+    def test_rejected_all_returns_empty_lists(self) -> None:
+        from deepretro.models.hallucination_helpers import filter_with_checker
+
+        def reject_all(product: str, pathways: list) -> tuple[int, list]:
+            del product, pathways
+            return 400, []
+
+        assert filter_with_checker(
+            "P", [["A"]], ["e"], [0.5], reject_all
+        ) == ([], [], [])
+
+    def test_length_mismatch_raises(self) -> None:
+        from deepretro.models.hallucination_helpers import filter_with_checker
+
+        with pytest.raises(ValueError, match="same length"):
+            filter_with_checker("P", [["A"], ["B"]], ["only_one"], [0.1, 0.2], None)
+
+    def test_unknown_returned_pathway_raises(self) -> None:
+        from deepretro.models.hallucination_helpers import filter_with_checker
+
+        def invent_pathway(product: str, pathways: list) -> tuple[int, list]:
+            del product, pathways
+            return 200, [["NOT", "IN", "INPUT"]]
+
+        with pytest.raises(ValueError, match="not present in original"):
+            filter_with_checker("P", [["A"]], ["e"], [0.5], invent_pathway)

--- a/deepretro/tests/test_utils_molecule.py
+++ b/deepretro/tests/test_utils_molecule.py
@@ -253,3 +253,23 @@ class TestDetectEightMemberRings:
     def test_invalid_smiles_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="Invalid SMILES string provided"):
             utils_molecule.detect_eight_member_rings(INVALID_SMILES)
+
+
+class TestCanonicalize:
+    """Tests for ``utils_molecule.canonicalize``."""
+
+    def test_non_canonical_input_is_canonicalized(self) -> None:
+        assert utils_molecule.canonicalize("C(O)C") == "CCO"
+
+    def test_already_canonical_is_stable(self) -> None:
+        assert utils_molecule.canonicalize(ETHANOL) == "CCO"
+
+    def test_equivalent_smiles_map_to_same_string(self) -> None:
+        aspirin_a = "CC(=O)Oc1ccccc1C(=O)O"
+        aspirin_b = "O=C(O)c1ccccc1OC(C)=O"
+        assert utils_molecule.canonicalize(aspirin_a) == utils_molecule.canonicalize(
+            aspirin_b
+        )
+
+    def test_invalid_smiles_returns_input_unchanged(self) -> None:
+        assert utils_molecule.canonicalize(INVALID_SMILES) == INVALID_SMILES

--- a/deepretro/utils/typing.py
+++ b/deepretro/utils/typing.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any
 
 RouteNode = Mapping[str, Any]
 Step = dict[str, Any]
 DependencyMap = dict[str, list[str]]
 ParseOutput = dict[str, Any]
+
+# A hallucination checker filters candidate pathways for one product.
+# ``(product_smiles, pathways) -> (status_code, kept_pathways)`` where a
+# status of 200 means at least one pathway was kept.
+HallucinationChecker = Callable[[str, list], tuple[int, list]]

--- a/deepretro/utils/utils_molecule.py
+++ b/deepretro/utils/utils_molecule.py
@@ -54,6 +54,35 @@ def is_valid_smiles(smiles: str) -> bool:
     return _parse_molecule(smiles) is not None
 
 
+def canonicalize(smiles: str) -> str:
+    """Return canonical SMILES, or the original string if parsing fails.
+
+    Parameters
+    ----------
+    smiles : str
+        Input SMILES string.
+
+    Returns
+    -------
+    str
+        Canonical SMILES, or the original string when RDKit cannot parse it.
+        Returning the input unchanged (rather than raising) lets callers use
+        the result as a stable cycle-detection key even for malformed input.
+
+    Examples
+    --------
+    >>> canonicalize("C(O)C")
+    'CCO'
+    >>> canonicalize("not_a_smiles")
+    'not_a_smiles'
+    """
+
+    molecule = _parse_molecule(smiles)
+    if molecule is None:
+        return smiles
+    return Chem.MolToSmiles(molecule, canonical=True)
+
+
 def substructure_matching(target_smiles: str, query_smiles: str) -> int:
     """Check whether a query molecule is a substructure of a target molecule.
 

--- a/docs/source/package/deepretro.agents.rst
+++ b/docs/source/package/deepretro.agents.rst
@@ -1,0 +1,49 @@
+deepretro.agents
+================
+
+The agentic tool-calling layer used by
+:class:`deepretro.algorithms.autosolve.AutoSolver` when
+``solve_mode="single_step_agent"``. The model may call tools to validate SMILES,
+check stability, check for hallucinations, or run Python in a sandbox, then emits
+the same tagged-JSON payload the non-agentic pipeline produces.
+
+.. code-block:: python
+
+   from deepretro.agents.tools import build_tool_registry
+   from deepretro.agents.sandbox import SubprocessSandbox
+   from deepretro.agents.loop import agentic_single_step
+
+   registry = build_tool_registry(tool_backend="sandbox", sandbox=SubprocessSandbox())
+   registry.execute("validate_smiles", {"smiles": "C(O)C"})  # -> canonical 'CCO'
+
+Sandbox security
+----------------
+
+``SubprocessSandbox`` runs model-written code in a subprocess that is
+**secret-scrubbed** (no provider API keys inherited), resource-limited
+(``RLIMIT_AS`` / ``RLIMIT_CPU`` / ``RLIMIT_NPROC`` / ``RLIMIT_FSIZE``),
+wall-clock bounded, and — on Linux with ``unshare`` — network-isolated. It is
+adequate for *semi-trusted* model-generated code; untrusted data is never
+interpolated into executed code. For stronger isolation, implement the
+``Sandbox`` protocol with a container backend (e.g. Podman ``--network=none``).
+
+Tools API
+---------
+
+.. automodule:: deepretro.agents.tools
+   :members:
+   :undoc-members:
+
+Sandbox API
+-----------
+
+.. automodule:: deepretro.agents.sandbox
+   :members:
+   :undoc-members:
+
+Agent loop API
+--------------
+
+.. automodule:: deepretro.agents.loop
+   :members:
+   :undoc-members:

--- a/docs/source/package/deepretro.algorithms.autosolve.rst
+++ b/docs/source/package/deepretro.algorithms.autosolve.rst
@@ -1,0 +1,47 @@
+deepretro.algorithms.autosolve
+==============================
+
+Recursive AiZynthFinder + LLM retrosynthesis solver. At each node AZ is tried
+first; when it cannot solve a molecule the LLM (or, under
+``solve_mode="single_step_agent"``, a tool-calling agent) proposes precursors,
+which are recursively solved until AZ solves every leaf. ``run_llm`` is the
+single owner of validity, stability, and hallucination filtering, so the agent
+path can never bypass the safety checks.
+
+.. code-block:: python
+
+   from deepretro.algorithms.autosolve import AutoSolver
+
+   # Non-agentic pipeline (default) with dependency-injected runners for testing:
+   solver = AutoSolver(
+       az_runner=lambda smiles, model: (False, []),
+       llm_runner=lambda molecule, **kw: ([["OC(=O)c1ccccc1O"]], ["hydrolysis"], [0.9]),
+       hallucination_mode="none",
+   )
+   output = solver.autosolve("CC(=O)Oc1ccccc1C(=O)O")
+
+   # Tool-calling agent mode:
+   agent_solver = AutoSolver(
+       solve_mode="single_step_agent",
+       tool_backend="sandbox",       # let the model write and run Python
+   )
+
+   # Top-K candidate routes for the batch runner:
+   routes = agent_solver.solve_multiple("CC(=O)Oc1ccccc1C(=O)O", k=3)
+
+Modes
+-----
+
+- ``solve_mode``: ``"pipeline"`` (default, non-agentic), ``"single_step_agent"``
+  (per-molecule tool-calling agent), or ``"orchestrator"`` (reserved; raises
+  ``NotImplementedError``).
+- ``tool_backend``: ``"structured"`` (validity/stability/hallucination tools) or
+  ``"sandbox"`` (adds a ``run_python`` code-execution tool). Ignored in
+  ``pipeline`` mode.
+
+API
+---
+
+.. automodule:: deepretro.algorithms.autosolve
+   :members:
+   :undoc-members:

--- a/docs/source/package/deepretro.batch.rst
+++ b/docs/source/package/deepretro.batch.rst
@@ -1,0 +1,31 @@
+deepretro.batch
+===============
+
+End-to-end batch retrosynthesis runner. Downloads a CSV from a public Google
+Sheet, (optionally) trains the hallucination checker, reads target molecules
+from a text file, runs each through
+:class:`deepretro.algorithms.autosolve.AutoSolver`, and dumps the routes as
+``<out>/<timestamp>/<molecule>/pathway_<i>.json``.
+
+Command line
+------------
+
+.. code-block:: bash
+
+   python scripts/run_batch.py \
+       --sheet-url "https://docs.google.com/spreadsheets/d/<ID>/export?format=csv&gid=<GID>" \
+       --molecules molecules.txt \
+       --out batch_output \
+       --solve-mode single_step_agent \
+       --tool-backend sandbox
+
+``--sheet-url`` and ``--molecules`` are required. The training step is a
+**template**: it runs only when the CSV carries ``product``/``reactants``/``label``
+columns, otherwise the batch falls back to the heuristic hallucination checker.
+
+API
+---
+
+.. automodule:: deepretro.batch
+   :members:
+   :undoc-members:

--- a/docs/source/package/deepretro.rst
+++ b/docs/source/package/deepretro.rst
@@ -61,7 +61,10 @@ Subpackages
 .. toctree::
    :maxdepth: 2
 
+   deepretro.algorithms.autosolve
    deepretro.algorithms.hallucination_checker
+   deepretro.agents
+   deepretro.batch
    deepretro.data.loader
    deepretro.models.hallucination_classifier
    deepretro.metadata

--- a/docs/superpowers/specs/2026-07-01-agentic-autosolve-design.md
+++ b/docs/superpowers/specs/2026-07-01-agentic-autosolve-design.md
@@ -1,269 +1,307 @@
 # Agentic tool-calling retrosynthesis in `deepretro/`
 
-**Status:** Approved design — pending 4-persona review before implementation
-**Branch:** `feat/agentic-autosolve` (off `dev`) → PR to `dev`
+**Status:** Approved design, revised after 4-persona review (Codex + adversarial + senior OSS
+maintainer + senior engineer). Ready to implement.
+**Branch:** `feat/agentic-autosolve` (off `dev`) → single PR to `dev` (no Claude co-author).
 **Date:** 2026-07-01
 
 ## 1. Goal
 
-Adapt DeepRetro's recursive retrosynthesis algorithm to run as an **agentic loop with
-tool calling**, living inside the `deepretro/` package. Three deliverables:
+Adapt DeepRetro's recursive retrosynthesis algorithm to run as an **agentic loop with tool
+calling**, inside the `deepretro/` package. Three deliverables:
 
 1. Port the recursive loop + metadata into `deepretro/` (built on the unmerged
    `origin/autosolve-pipeline` branch, rewired to current `dev` APIs).
 2. An agentic layer where the LLM can call tools — **molecule validity**, **stability**,
-   **hallucination** (template), and **write-and-run-Python-in-a-sandbox** — with tool
-   calling and sandbox code-execution both selectable.
+   **hallucination** (template), and **write-and-run-Python-in-a-sandbox** — with structured
+   tool calling and sandbox code-execution both selectable.
 3. A batch script: download a CSV from Google Sheets → train the hallucination checker
-   (template) → run molecules from a `.txt` file through the full algorithm → dump
-   outputs as `folder/<timestamp>/<molecule>/pathway_<i>.json`.
+   (template) → run molecules from a `.txt` file → dump `folder/<timestamp>/<molecule>/pathway_<i>.json`.
 
-## 2. Current state (verified against `dev`)
+## 2. Current state (verified on `dev`)
 
-Already in `deepretro/` on `dev`:
-
-- **LLM layer** (100% `litellm`): `utils/llm_interface.py` (provider classes + `call()`),
-  `utils/llm.py` (`call_LLM`, `llm_pipeline` — single-step retrosynthesis with rising-temperature
-  retries + validity/stability/hallucination filters), `utils/llm_helpers.py`
-  (`build_completion_params` — the one place that assembles `litellm.completion(**params)`).
+- **LLM layer** (100% `litellm`): `utils/llm_interface.py` (`LLMInterface.call()` returns a
+  **text-only** `LLMResponse(status_code, text)`), `utils/llm.py` (`call_LLM`, `llm_pipeline`
+  — single-step retrosynthesis: rising-temperature retry loop → parse → `validate_split_json`
+  → `validity_check` → optional `filter_stable_pathways` → optional `filter_hallucination_pathways`),
+  `utils/llm_helpers.py` (`build_completion_params` — the one place assembling
+  `litellm.completion(**params)`; **has no `tools`/`tool_choice` path today**).
 - **Checks**: `algorithms/stability_checker.py::check_molecule_stability`,
   `algorithms/hallucination_checker.py::calculate_hallucination_score` (heuristic),
   `utils/utils_molecule.py::is_valid_smiles` / `validity_check`,
-  `algorithms/pipeline_checks.py::hallucination_checker` (pipeline hook).
+  `algorithms/pipeline_checks.py::hallucination_checker` (order-preserving pathway filter).
 - **ML hallucination**: `models/hallucination_classifier.py::HallucinationClassifier`
-  (XGBoost via DeepChem `GBDTModel`; `fit/evaluate/predict_probability/save/load`),
-  `models/hallucination_helpers.py::MLChecker` + `resolve_hallucination(mode, classifier)`.
-- **Metadata**: `metadata.py::recommend_reaction_metadata` (reagent→conditions→literature agents).
-- **AZ**: `utils/az.py::run_az(smiles, az_model)`. **Parse**: `utils/parse.py::format_output`.
-- **Training data path**: `featurizers/reactionstep.py::ReactionStepFeaturizer`,
-  `data/loader.py::ReactionDataLoader` (cols `product`/`reactants`/`label`) + `stratified_split`.
+  (XGBoost via DeepChem `GBDTModel`; `fit`, `evaluate`, `predict_probability`,
+  `save(save_dir)`, `load(save_dir)`; exposes `.featurizer`, `.threshold`),
+  `models/hallucination_helpers.py::MLChecker` + `resolve_hallucination(mode, classifier)`
+  (returns a `Callable[[str, list], tuple[int, list]]` or `None`).
+- **Metadata**: `metadata.py::recommend_reaction_metadata`. **AZ**: `utils/az.py::run_az`
+  (can raise `FileNotFoundError`/`ImportError` before returning a status tuple).
+  **Parse**: `utils/parse.py::format_output`. **Training path**: `data/loader.py::ReactionDataLoader`
+  (cols `product`/`reactants`/`label`) + `stratified_split`, `featurizers/reactionstep.py`.
+- `requests` is a direct dependency (via `aizynthfinder`/tooling); `httpx` is only transitive.
 
-Missing on `dev`: the recursive loop, any tool-calling/agent layer, any sandbox. There is a
-dead `TOOLS` list in `utils/variables.py` (never imported) and a one-tool prototype on
-`origin/agentic-solution` (`agentic_call_LLM` + `src/utils/tools.py`).
+Missing on `dev`: the recursive loop, any tool-calling/agent layer, any sandbox. A dead `TOOLS`
+list sits unused in `utils/variables.py`; `origin/agentic-solution` has a one-tool prototype
+(`agentic_call_LLM` + `src/utils/tools.py`) — a **pattern reference only**; 3 of the 4 tools and
+the entire sandbox here are net-new.
 
-## 3. Reuse decision: build on `origin/autosolve-pipeline`
+## 3. Reuse + adaptation layer
 
-That branch's `deepretro/algorithms/autosolve.py` (~636 lines) already implements the
-`AutoSolver` (recursive `solve`, `single_step`, `parse`, `add_metadata`, `autosolve`,
-`run_llm`) with dependency injection and ~660 lines of tests. It is **not** cleanly rebasable —
-it targets the older `autosolve-foundations` API that `dev`'s merged hallucination layer
-replaced. Reuse it as the structural basis with a **bounded adaptation layer**:
+`origin/autosolve-pipeline:deepretro/algorithms/autosolve.py` (~636 lines) implements `AutoSolver`
+(recursive `solve`, `single_step`, `parse`, `add_metadata`, `autosolve`, `run_llm`) with DI, plus
+~660 lines of tests. It targets the older `autosolve-foundations` API and is **not** cleanly
+rebasable. Reuse it as the structural basis with this bounded adaptation on `dev`:
 
-| Branch import | Status on `dev` | Adaptation |
+| Branch symbol | On `dev` | Adaptation |
 |---|---|---|
-| `hallucination_helpers.filter_with_checker` | absent (replaced by `MLChecker`) | call `checker(product, pathways) -> (status, kept)` where `checker = resolve_hallucination(mode, clf)` |
-| `hallucination_helpers.HallucinationPredictor` | absent | type as the checker `Callable`; drop the alias |
-| `utils.typing.HallucinationChecker` | absent | add alias `Callable[[str, list], tuple[int, list]]` |
-| `utils_molecule.canonicalize` | absent | port the trivial RDKit wrapper from foundations |
+| `hallucination_helpers.filter_with_checker(molecule, pathways, explanations, confidence, checker)` | absent | **Add it** to `dev`'s `hallucination_helpers.py`: `checker=None → passthrough`; else `status, kept = checker(molecule, pathways)`; `status != 200 → ([],[],[])`; realign `explanations`/`confidence` to `kept` by **order-preserving index walk** (dev checkers preserve order). Unit-tested. |
+| `hallucination_helpers.HallucinationPredictor` (protocol w/ `predict_single`) | absent | Drop it. Type `hallucination_classifier: Any` (dev contract: an object with `predict_probability`/`threshold`/`featurizer`, or a `str`/`Path` — whatever `resolve_hallucination("ml", …)` accepts). |
+| `utils.typing.HallucinationChecker` | absent | Add alias `HallucinationChecker = Callable[[str, list], tuple[int, list]]`. |
+| `utils_molecule.canonicalize(smiles) -> str` | absent | Port the trivial RDKit wrapper (`MolToSmiles(MolFromSmiles(s), canonical=True)`; `""` on invalid). Unit-tested. |
 | `run_az`, `llm_pipeline`, `format_output`, `recommend_reaction_metadata`, recommender types | present | no change |
 
 ## 4. Architecture
 
 ```
 deepretro/
-├── algorithms/autosolve.py     port AutoSolver (rewired) + reasoning_mode / tool_backend flags
+├── algorithms/autosolve.py     ported AutoSolver (rewired) + solve_mode/tool_backend + solve_multiple
 ├── agents/                     NEW subpackage
 │   ├── __init__.py
-│   ├── tools.py                tool registry: schemas + executors + dispatcher
-│   ├── sandbox.py              subprocess sandbox behind a Sandbox protocol
-│   └── loop.py                 agentic_single_step() (full) + agentic_orchestrator() (scaffold)
+│   ├── tools.py                tool registry (OpenAI function schemas) + executors + dispatcher
+│   ├── sandbox.py              Sandbox protocol + SubprocessSandbox (secret-scrubbed, rlimited)
+│   └── loop.py                 agentic_single_step() (full) + agentic_orchestrator() (NotImplementedError)
 ├── utils/utils_molecule.py     + canonicalize()
-└── utils/typing.py             + HallucinationChecker alias
+├── utils/typing.py             + HallucinationChecker alias
+├── utils/llm_helpers.py        build_completion_params gains optional tools/tool_choice
+├── utils/llm.py                extract validity+stability filters as reusable helpers (already ~separate)
+└── models/hallucination_helpers.py  + filter_with_checker() (with realignment)
 scripts/run_batch.py            NEW batch driver
 ```
 
-### 4.1 `AutoSolver` flags (item: "both, flag-selectable")
+### 4.1 `AutoSolver` flags and post-filtering (item: "both, flag-selectable")
 
-`AutoSolver.__init__` gains:
+Constructor gains:
+- `solve_mode: {"pipeline", "single_step_agent", "orchestrator"} = "pipeline"` (renamed from
+  `reasoning_mode` to avoid colliding with `enable_thinking`/reasoning-effort concepts).
+- `tool_backend: {"structured", "sandbox"} = "structured"` (renamed value `tools`→`structured`;
+  **ignored in `pipeline` mode**, documented as such).
+- `sandbox: Sandbox | None = None` (injectable; defaults to `SubprocessSandbox`).
 
-- `reasoning_mode: {"pipeline", "single_step_agent", "orchestrator"} = "pipeline"`
-- `tool_backend: {"tools", "sandbox"} = "tools"`
-- `sandbox: Sandbox | None = None` (injectable; defaults to the subprocess backend)
+`run_llm(molecule)` is the **single owner of post-filtering** for both modes, so the agent path
+can never bypass the safety filters:
 
-Behavior:
+- **`pipeline`** (default, unchanged behavior): call `llm_pipeline(..., stability_check=self.stability_check,
+  hallucination_check=False)` (validity + stability owned by `llm_pipeline`; hallucination turned
+  **off** there to avoid a double pass), then apply the resolved hallucination checker via
+  `filter_with_checker`.
+- **`single_step_agent`** (fully built): call `agents.loop.agentic_single_step(...)` to get **raw**
+  parsed `(pathways, explanations, confidence)`, then apply the shared safety filter
+  `_apply_safety_filters` = `validity_check` → `filter_stable_pathways` (if `stability_check`) →
+  `filter_with_checker` (hallucination). Same output contract as `llm_pipeline`.
+- **`orchestrator`**: `agents.loop.agentic_orchestrator` **raises `NotImplementedError`** with a
+  clear message. Interface + flag wiring exist; not offered in the batch CLI. (Non-goal §9.)
 
-- **`pipeline`** (default) — unchanged: `run_llm` calls `llm_pipeline`. Nothing is ripped out.
-- **`single_step_agent`** (fully built) — `run_llm`/`single_step` calls
-  `deepretro.agents.loop.agentic_single_step`, which lets the LLM call the tools to
-  self-correct its proposed precursors, then returns `(pathways, explanations, confidence)`
-  in the **same shape** `llm_pipeline` returns. The deterministic validity/stability/
-  hallucination filters still run afterward as a safety net — the agent's self-checks
-  augment, never replace, them.
-- **`orchestrator`** (scaffold, flag-wired, minimal impl) — `deepretro.agents.loop.agentic_orchestrator`
-  gives one agent tool-driven control of the whole search. Interface + wiring present;
-  `single_step_agent` is the deep implementation.
+Hallucination is owned in exactly one place (`filter_with_checker` in `run_llm`) for both modes.
 
-The recursion in `solve()` is unchanged regardless of mode (§5).
+### 4.2 Tools (`agents/tools.py`) — OpenAI function-call format
 
-### 4.2 Tools (`agents/tools.py`)
-
-Ported/extended from `origin/agentic-solution:src/utils/tools.py`: Anthropic/litellm tool
-schema dicts + executor functions + a `TOOL_DEFINITIONS`/`TOOL_EXECUTORS` registry +
-`execute_tool(name, input) -> dict` dispatcher + `get_available_tools()`.
+litellm's tool calling normalizes to OpenAI format, so schemas are stored as
+`{"type": "function", "function": {"name", "description", "parameters": <json-schema>}}` (not
+Anthropic-native `input_schema`). Registry + `execute_tool(name, input) -> dict` dispatcher +
+`get_tool_schemas(tool_backend) -> list`.
 
 | tool | signature | wraps | returns |
 |---|---|---|---|
-| `validate_smiles` | `(smiles, context?)` | `is_valid_smiles` + RDKit canonical | `{valid, canonical_smiles, error, context}` |
+| `validate_smiles` | `(smiles, context?)` | `is_valid_smiles` + `canonicalize` | `{valid, canonical_smiles, error, context}` |
 | `check_stability` | `(smiles)` | `check_molecule_stability` | `{assessment, stability_score, issues}` |
-| `check_hallucination` | `(product, reactants)` | `resolve_hallucination`/`MLChecker` | **TEMPLATE**: `{configured: false, fallback_severity, note}` when no classifier; real verdict when one is injected. Flagged for the other contributor. |
-| `run_python` | `(code)` | `agents/sandbox.py` | `{ok, stdout, stderr, error}` — RDKit + `deepretro.algorithms` checkers importable |
+| `check_hallucination` | `(product, reactants)` | the checker from `resolve_hallucination(mode, clf)` | verdict from the resolved checker. **TEMPLATE seam:** the executor is bound to the resolved checker at registry-build time; in `heuristic` mode it uses the working heuristic checker (never a no-op), in `ml` mode it uses the injected classifier, in `none` mode the tool is **omitted from the registry**. The ML wiring is what another contributor completes. |
+| `run_python` | `(code)` | `agents/sandbox.py` | `{ok, stdout, stderr, error}` — RDKit + `deepretro.algorithms` importable |
 
-The tool registry is built once and passed into the agent loop; `check_hallucination`'s
-executor is bound to whatever `resolve_hallucination(mode, classifier)` returns so the ML
-classifier can be swapped in later without touching tool code.
+`tool_backend="structured"` exposes `validate_smiles`/`check_stability`/`check_hallucination`;
+`tool_backend="sandbox"` exposes `run_python` (+ the read-only checks). The registry is built per
+`AutoSolver`, binding `check_hallucination` to the resolved checker so the ML classifier swaps in
+without touching tool code.
 
-### 4.3 Sandbox (`agents/sandbox.py`) — subprocess backend
+### 4.3 Sandbox (`agents/sandbox.py`) — hardened subprocess (the chosen backend)
 
 ```python
 class Sandbox(Protocol):
-    def run(self, code: str, *, timeout_s: float, mem_mb: int) -> SandboxResult: ...
+    def run(self, code: str, *, timeout_s: float = 10.0, mem_mb: int = 2048) -> SandboxResult: ...
 
-class SubprocessSandbox:  # default
-    # writes code to a temp file, runs `python <file>` in a subprocess with:
-    #   - resource.setrlimit(RLIMIT_AS, mem_mb) and RLIMIT_CPU (POSIX)
-    #   - a fresh temp cwd, cleaned up after
-    #   - captured stdout/stderr, hard wall-clock timeout (kill on expiry)
-    # returns SandboxResult(ok, stdout, stderr, error)
+class SubprocessSandbox:   # default
+    # - writes code to a temp file in a fresh temp cwd (cleaned up after)
+    # - MANDATORY secret scrubbing: child runs with a minimal allowlist env
+    #   (PATH, LANG, and nothing else) — NO ANTHROPIC_API_KEY/OPENAI_API_KEY/etc. inherited
+    # - POSIX rlimits (best-effort, per-limit try/except): RLIMIT_AS (mem_mb*1024*1024, with a
+    #   floor of 1024 MB so RDKit/deepretro imports don't MemoryError), RLIMIT_CPU (ceil timeout),
+    #   RLIMIT_NPROC, RLIMIT_FSIZE
+    # - hard wall-clock timeout: kill the child (and its process group) on expiry
+    # - best-effort network isolation: wrap with `unshare -rn` when available (Linux); on macOS
+    #   there is NO network isolation — documented ceiling
+    # - captured stdout/stderr; returns SandboxResult(ok, stdout, stderr, error)
 ```
 
-`ponytail:` comment marks the isolation ceiling — rlimit + no-inherited-fds is adequate for
-**LLM-generated, non-adversarial** chem code, but is **not** namespace/network isolation;
-upgrade path is a `PodmanSandbox` implementing the same `Sandbox` protocol if code ever
-becomes untrusted. Network is best-effort suppressed (cleared proxy env; documented ceiling).
+`ponytail:` comment names the ceiling: secret-scrubbing + rlimits + best-effort `unshare -n` is
+adequate for **LLM-generated, semi-trusted** chem code, but is **not** a true jail; upgrade path is
+a `PodmanSandbox` (`--network=none`, read-only rootfs) implementing the same `Sandbox` protocol.
+**Threat-model statement in the module + docs:** untrusted Google-Sheet CSV / molecule-file text is
+NEVER interpolated into `run_python` code; the agent generates code from its own reasoning; the
+primary mitigations are secret-scrubbing (no key exfiltration) + resource caps + (optional) network
+isolation. `RLIMIT_AS` is unenforced on macOS — treated as best-effort there.
 
-### 4.4 Agent loop (`agents/loop.py`)
+### 4.4 Agent loop (`agents/loop.py`) — widened tool-response contract
 
-Ported/extended from `origin/agentic-solution:agentic_call_LLM`. Uses litellm's OpenAI-style
-tool calling through the existing `build_completion_params` seam:
+The text-only `LLMInterface.call()` cannot carry `tool_calls`, so the loop calls
+`litellm.completion` **directly** through an extended `build_completion_params(..., tools=…,
+tool_choice=…)` and reads the **full** message (`content` + `tool_calls`) and `finish_reason`:
 
 ```python
 def agentic_single_step(
-    molecule, model, *, tools, tool_backend, max_iterations=6,
-    llm_runner=None, enable_thinking=True, max_output_tokens=None,
+    molecule, model, *, tool_registry, tool_backend, max_iterations=6,
+    llm_runner=None, enable_thinking=False, max_output_tokens=None,
 ) -> tuple[list[Pathway], list[str], list[float]]:
-    # loop: completion(**params, tools=tool_defs)
-    #   while finish_reason == "tool_use" / message.tool_calls and iter < max_iterations:
-    #       for each tool_call: execute_tool(...) -> append tool result message
-    #   on final answer: parse into (pathways, explanations, confidence)  [same shape as llm_pipeline]
+    # system prompt = the pipeline's retrosynthesis prompt + "you may call tools to check
+    #   candidates; when done, emit the SAME <json> payload the pipeline expects"
+    # loop while message.tool_calls is non-empty and iter < max_iterations:
+    #     append assistant turn (with tool_calls); for each tool_call:
+    #         execute_tool(name, json.loads(arguments)) -> append role="tool" result msg
+    # on a final (no-tool_calls) message: reuse parse_response/validate_split_json ->
+    #     (pathways, explanations, confidence)   [same shape as llm_pipeline]
+    # if max_iterations hit with no final answer: return ([], [], []) and log the reason
 ```
 
-`tool_backend="sandbox"` restricts the exposed tools to `run_python` (+ read-only checks);
-`tool_backend="tools"` exposes the structured check tools. `llm_runner` is injectable for tests
-(a fake returning a scripted `tool_use` then a final answer — no network). Iteration cap and
-per-tool error capture prevent runaway loops.
+Details fixed per review:
+- Loop condition is **non-empty `message.tool_calls`** (litellm normalizes Anthropic to
+  `finish_reason=="tool_calls"`); no reliance on a literal `"tool_use"`.
+- `enable_thinking=False` by default in the tool loop — extended thinking + multi-turn tool use
+  returns Anthropic HTTP 400 on the second turn unless the signed thinking block is preserved.
+- `max_iterations` exhausted → `([], [], [])` → `run_llm` → `unsolved_leaf`; asserted in a
+  fake-runner iteration-cap test.
+- `llm_runner` injectable: a fake scripting `tool_calls` then a final `<json>` answer — no network.
 
 ## 5. Data flow (recursion terminates when AZ solves)
 
 ```
-autosolve(smiles):
-    route_tree, solved = solve(smiles, depth=0, visited=set())
-    output = parse(route_tree)                 # format_output
-    output = add_metadata(output)              # recommend_reaction_metadata
-    return output, solved
+autosolve(smiles):  route_tree, solved = solve(smiles); parse; add_metadata
 
-solve(molecule, depth, visited):
-    m = canonicalize(molecule)
-    if depth >= max_depth or m in visited:  return unsolved_leaf(m), False   # safety guards only
-    visited.add(m)
-    solved, routes = run_az(m, az_model)
-    if solved:  return az_route(routes), True          # ✅ AZ found building blocks → branch ends
-    # AZ could not solve → go deeper
-    pathways, expl, conf = single_step(m)              # pipeline OR agent, per reasoning_mode
-    pathways = validity / stability / hallucination filters
-    for pathway in pathways (best-first):
-        child_results = [solve(p, depth+1, visited) for p in pathway]
-        if all(child solved):  return assemble(pathway, child_results), True
+solve(molecule, visited=None, depth=0):
+    m = _clean_smiles(molecule);  if not m: return unsolved_leaf, False
+    canonical = canonicalize(m)
+    if depth >= max_depth: return unsolved_leaf, False          # safety guard
+    branch_visited = set(visited or ())                         # PER-BRANCH COPY (path-only dedup)
+    if canonical in branch_visited: return unsolved_leaf, False # cycle guard
+    branch_visited.add(canonical)
+    try: az_solved, az_routes = az_runner(m, az_model)          # wrapped: FileNotFoundError/ImportError -> unsolved_leaf
+    except (FileNotFoundError, ImportError, ...): return unsolved_leaf, False
+    if az_solved and az_routes: return az_routes[0], True       # ✅ AZ found building blocks -> branch ends
+    pathways, expl, conf = run_llm(m)                           # pipeline OR agent, per solve_mode; single-owner filtering
+    for i, pathway in enumerate(pathways, best-first):
+        children, all_solved = _solve_pathway(pathway, branch_visited, depth)   # recurse each reactant
+        if all_solved: return reaction_tree(m, children, [conf[i]]), True
     return best_effort_partial, False
 ```
 
-A branch stops **only** when AZ solves the node (purchasable/building-block leaf). A full
-pathway is solved iff every leaf bottoms out at an AZ-solved node. `max_depth`/cycle-detection
-are guards against infinite recursion when AZ never solves a path. This is exactly
-`src/rec_prithvi.py::rec_run_prithvi`'s behavior, preserved by `autosolve-pipeline::solve`.
+A branch stops **only** when AZ solves the node. A pathway is solved iff every leaf bottoms out at
+an AZ-solved node. `visited` is a **per-branch copy** (path-only dedup — the `autosolve-pipeline`
+semantics, correct for a tree; this differs from `rec_prithvi`'s global set, and we adopt the
+per-branch copy deliberately). `max_depth`/cycle guards prevent infinite recursion.
+
+### 5.1 Top-K routes (`solve_multiple`)
+
+`solve()` returns a single route. Add:
+```python
+def solve_multiple(self, smiles, k=3) -> list[tuple[dict, bool]]:
+    # AZ first: if AZ solves, return [(az_route, True)]
+    # else: pathways,_,conf = run_llm(smiles); for each of the top-k pathways, solve each reactant
+    #       with its OWN fresh visited set -> reaction_tree; return up to k (route, solved) tuples
+```
+Each candidate route is independent (fresh visited), producing the `pathway_<i>.json` deliverable.
 
 ## 6. Batch script (`scripts/run_batch.py`)
 
-CLI:
 ```
 python scripts/run_batch.py \
   --sheet-url <google-sheets /export?format=csv URL>   # REQUIRED (public export, no auth)
   --molecules <path/to/molecules.txt>                  # REQUIRED (one SMILES per line)
-  --out <output-dir> \
-  --reasoning-mode {pipeline,single_step_agent,orchestrator} \
-  --tool-backend {tools,sandbox} \
-  --model <litellm model id> \
-  --classifier <optional path to trained HallucinationClassifier> \
-  --top-k <int, default 3>
+  --out <output-dir> --solve-mode {pipeline,single_step_agent} \  # orchestrator NOT offered
+  --tool-backend {structured,sandbox} --model <litellm id> \
+  --az-model <default USPTO> --classifier <optional trained-model dir> --top-k <int, default 3>
 ```
 
 Steps:
-
-1. `download_sheet_csv(export_url, dest)` — plain `httpx`/`requests` GET on the
-   `/export?format=csv` URL (published/link-shared sheet, no auth). Fails loudly on non-200.
-2. `train_hallucination_checker(csv, out_dir)` — **TEMPLATE**: if the CSV has `product`/
-   `reactants`/`label`, run `ReactionDataLoader.create_dataset` → `stratified_split` →
-   `HallucinationClassifier.fit` → `.evaluate` → `.save`; return the saved path. If columns
-   are absent, log "template — supply a labeled CSV" and skip (batch still runs with the
-   heuristic hallucination mode). Clearly delimited for the other contributor.
-3. `read_molecules(txt)` — one SMILES per line; blank/`#`-comment lines skipped.
-4. Per molecule → **multiple routes**: take the top-K first-step candidate pathways the
-   LLM/agent proposes, solve each to completion, and write each as
-   `out/<timestamp>/<safe_molecule>/pathway_<i>.json`. `<timestamp>` is computed once at
-   startup (`YYYY-MM-DD_HH-MM-SS`); `<safe_molecule>` is a filesystem-safe slug of the SMILES.
-   Per-molecule failures write `error.json` and never abort the batch.
-
-**Multiple-pathways note:** the current `AutoSolver.solve` returns only the first fully-solved
-route (DFS). To satisfy the `pathway.json (multiple)` folder shape, the script drives the
-solver to emit the top-K candidate routes per molecule (via the first-level candidate
-pathways). This is additive; `solve`'s single-route contract is unchanged.
+1. `download_sheet_csv(export_url, dest)` — `requests.get` on the `/export?format=csv` URL
+   (published/link-shared, no auth); raise on non-200.
+2. `train_hallucination_checker(csv, save_dir) -> str | None` — **TEMPLATE**: if the CSV has
+   `product`/`reactants`/`label`, `ReactionDataLoader.create_dataset` → `stratified_split` →
+   `clf = HallucinationClassifier(model_dir=save_dir)` → `clf.fit(train)` → `clf.evaluate(test)`
+   → `clf.save(save_dir)` (explicit `save_dir`; the function returns `save_dir`). If columns are
+   absent: log "template — supply a labeled CSV", return `None`, batch continues in `heuristic`
+   hallucination mode. Clearly delimited for the other contributor.
+3. `read_molecules(txt)` — one SMILES per line; blank/`#` lines skipped.
+4. Per molecule → `AutoSolver(...).solve_multiple(smiles, k=top_k)`; parse + add_metadata each
+   route; write `out/<timestamp>/<safe_molecule>/pathway_<i>.json`. `<timestamp>` computed once
+   at startup (`YYYY-MM-DD_HH-MM-SS`); `<safe_molecule>` = filesystem-safe slug. Per-molecule
+   `try/except` → `error.json`; the batch never aborts.
 
 ## 7. Error handling
 
-- LLM/tool/sandbox failures degrade gracefully: status codes, `unsolved_leaf`, structured
-  sandbox errors, capped agent iterations. No exception escapes a single molecule's solve.
-- Batch: per-molecule `try/except` → `error.json`; the run continues.
-- Sandbox: wall-clock timeout kills the child; OOM/rlimit → structured error, not a crash.
-- Config: missing `--sheet-url`/`--molecules` → argparse error; missing API keys → clear message.
+- `solve` wraps `az_runner`/AZ internals (`FileNotFoundError`/`ImportError`) → `unsolved_leaf`,
+  so no exception escapes a single molecule's solve. LLM/tool/sandbox failures degrade to status
+  codes / `unsolved_leaf` / structured errors. Agent iterations capped.
+- Batch: per-molecule `try/except` → `error.json` backstop; run continues.
+- Sandbox: wall-clock timeout kills the child group; OOM/rlimit → structured error.
+- Missing `--sheet-url`/`--molecules` → argparse error; missing API keys → clear message.
 
 ## 8. Testing
 
-- `agents/tools.py`: each executor (valid/invalid SMILES, stability assessment,
-  hallucination template stub + injected-classifier verdict, `run_python` happy/error);
-  dispatcher unknown-tool path.
-- `agents/sandbox.py`: happy path, timeout kill, memory-cap trip, stderr capture,
-  temp-dir cleanup.
-- `agents/loop.py`: fake `llm_runner` scripting `tool_use` → final answer; asserts tools are
-  invoked, iteration cap respected, output shape matches `llm_pipeline`.
-- `algorithms/autosolve.py`: `reasoning_mode` wiring with injected `az_runner`/`llm_runner`
-  fakes (no network); recursion terminates on AZ-solve; `canonicalize` cycle detection.
-- `scripts/run_batch.py`: temp dirs + fake solver → verifies folder structure, top-K files,
-  `error.json` on failure; `download_sheet_csv` with a stubbed HTTP response.
-- `utils_molecule.canonicalize`: canonical-form + invalid input.
+- `models/hallucination_helpers.filter_with_checker`: realignment correctness (kept subset keeps
+  matching expl/conf; `status!=200 → empty`; `checker=None → passthrough`).
+- `utils_molecule.canonicalize`: canonical form + invalid input.
+- `agents/tools.py`: each executor (valid/invalid SMILES; stability assessment; `check_hallucination`
+  heuristic verdict + injected-classifier verdict + omitted in `none` mode; `run_python` happy/error);
+  unknown-tool dispatch; schemas are OpenAI function format.
+- `agents/sandbox.py`: happy path; timeout kill; stderr capture; temp-dir cleanup; **secret scrub**
+  (assert `ANTHROPIC_API_KEY` set in parent is NOT visible to child); memory-cap test marked
+  **Linux-only** (`RLIMIT_AS` unenforced on macOS).
+- `agents/loop.py`: fake `llm_runner` scripting `tool_calls` → final answer; asserts tools invoked,
+  output shape matches `llm_pipeline`, iteration cap → `([],[],[])`.
+- `algorithms/autosolve.py`: `solve_mode` wiring with injected `az_runner`/`llm_runner` fakes (no
+  network); AZ-solve terminates recursion; per-branch visited/cycle detection; `run_llm` applies
+  safety filters in agent mode; `solve_multiple` yields ≤k independent routes; AZ raising →
+  `unsolved_leaf`; `orchestrator` → `NotImplementedError`.
+- `scripts/run_batch.py`: temp dirs + fake solver → folder structure, top-K files, `error.json`;
+  `download_sheet_csv` with a stubbed `requests` response.
 
 Style: dependency injection + real pharmaceutical molecules (aspirin/paracetamol), **no
-monkeypatch/MagicMock** (matches the existing suite). Live-LLM tests marked `slow`/skippable.
-`uv run pytest`; `ruff check`/`ruff format`; `ty`; numpydoc docstrings with usage examples.
+monkeypatch/MagicMock**; live-LLM tests marked `slow`/skippable. `uv run pytest`; `ruff
+check`/`ruff format`; `ty`; numpydoc docstrings with usage examples.
 
 ## 9. Non-goals / templates
 
-- **Hallucination trained-model wiring** — `check_hallucination` tool + `train_hallucination_checker`
-  are templates; another contributor completes them. The heuristic path remains fully functional.
+- **Hallucination trained-model wiring** — `check_hallucination` (ml mode) + `train_hallucination_checker`
+  are templates for another contributor. The heuristic path is fully functional throughout.
 - **Google auth** — none; public CSV export URL only.
-- **Top-level orchestrator** — scaffolded + flag-wired, minimal impl; `single_step_agent` is
-  the fully-built agent mode.
-- **Podman/remote sandbox** — protocol seam only; subprocess backend ships.
-- No changes to the Flask API / `src/` tree; no changes to the default `pipeline` behavior.
+- **Top-level orchestrator** — flag + interface only; `agentic_orchestrator` raises
+  `NotImplementedError`; not offered in the batch CLI.
+- **Podman/remote sandbox** — protocol seam only; hardened subprocess ships.
+- No changes to the Flask API / `src/` tree; the default `pipeline` behavior is unchanged.
 
 ## 10. Required inputs still needed from the user
 
 - The Google Sheets `/export?format=csv` URL.
-- The path to the molecules `.txt` file (and confirmation of one-SMILES-per-line format).
+- The molecules `.txt` path (one SMILES per line).
 
-Both are wired as required CLI args with placeholders + TODO so the script is runnable the
-moment they are supplied; their absence does not block implementation or tests.
+Wired as required CLI args with placeholders + TODO; absence blocks neither implementation nor tests.
 
 ## 11. Process
 
-Spec → **4-persona review** (Codex, adversarial reviewer, senior open-source dev, senior
-engineer) → revise → implement (TDD) → PR to `dev` (no Claude co-author).
+Spec (this doc) → 4-persona review **(done; incorporated)** → implement (TDD, logically-ordered
+commits) → single PR to `dev` (no Claude co-author). Reviewers suggested stacked PRs; deferring to
+the single-PR request, splittable on ask.
+```
+Implementation order (commits): (1) adaptation layer — canonicalize, HallucinationChecker alias,
+filter_with_checker, extracted safety filters + tests; (2) AutoSolver port + solve_mode/solve_multiple
++ tests; (3) agents/ subpackage — tools, sandbox, loop + tests; (4) scripts/run_batch.py + training
+template + tests.
+```

--- a/docs/superpowers/specs/2026-07-01-agentic-autosolve-design.md
+++ b/docs/superpowers/specs/2026-07-01-agentic-autosolve-design.md
@@ -1,0 +1,269 @@
+# Agentic tool-calling retrosynthesis in `deepretro/`
+
+**Status:** Approved design — pending 4-persona review before implementation
+**Branch:** `feat/agentic-autosolve` (off `dev`) → PR to `dev`
+**Date:** 2026-07-01
+
+## 1. Goal
+
+Adapt DeepRetro's recursive retrosynthesis algorithm to run as an **agentic loop with
+tool calling**, living inside the `deepretro/` package. Three deliverables:
+
+1. Port the recursive loop + metadata into `deepretro/` (built on the unmerged
+   `origin/autosolve-pipeline` branch, rewired to current `dev` APIs).
+2. An agentic layer where the LLM can call tools — **molecule validity**, **stability**,
+   **hallucination** (template), and **write-and-run-Python-in-a-sandbox** — with tool
+   calling and sandbox code-execution both selectable.
+3. A batch script: download a CSV from Google Sheets → train the hallucination checker
+   (template) → run molecules from a `.txt` file through the full algorithm → dump
+   outputs as `folder/<timestamp>/<molecule>/pathway_<i>.json`.
+
+## 2. Current state (verified against `dev`)
+
+Already in `deepretro/` on `dev`:
+
+- **LLM layer** (100% `litellm`): `utils/llm_interface.py` (provider classes + `call()`),
+  `utils/llm.py` (`call_LLM`, `llm_pipeline` — single-step retrosynthesis with rising-temperature
+  retries + validity/stability/hallucination filters), `utils/llm_helpers.py`
+  (`build_completion_params` — the one place that assembles `litellm.completion(**params)`).
+- **Checks**: `algorithms/stability_checker.py::check_molecule_stability`,
+  `algorithms/hallucination_checker.py::calculate_hallucination_score` (heuristic),
+  `utils/utils_molecule.py::is_valid_smiles` / `validity_check`,
+  `algorithms/pipeline_checks.py::hallucination_checker` (pipeline hook).
+- **ML hallucination**: `models/hallucination_classifier.py::HallucinationClassifier`
+  (XGBoost via DeepChem `GBDTModel`; `fit/evaluate/predict_probability/save/load`),
+  `models/hallucination_helpers.py::MLChecker` + `resolve_hallucination(mode, classifier)`.
+- **Metadata**: `metadata.py::recommend_reaction_metadata` (reagent→conditions→literature agents).
+- **AZ**: `utils/az.py::run_az(smiles, az_model)`. **Parse**: `utils/parse.py::format_output`.
+- **Training data path**: `featurizers/reactionstep.py::ReactionStepFeaturizer`,
+  `data/loader.py::ReactionDataLoader` (cols `product`/`reactants`/`label`) + `stratified_split`.
+
+Missing on `dev`: the recursive loop, any tool-calling/agent layer, any sandbox. There is a
+dead `TOOLS` list in `utils/variables.py` (never imported) and a one-tool prototype on
+`origin/agentic-solution` (`agentic_call_LLM` + `src/utils/tools.py`).
+
+## 3. Reuse decision: build on `origin/autosolve-pipeline`
+
+That branch's `deepretro/algorithms/autosolve.py` (~636 lines) already implements the
+`AutoSolver` (recursive `solve`, `single_step`, `parse`, `add_metadata`, `autosolve`,
+`run_llm`) with dependency injection and ~660 lines of tests. It is **not** cleanly rebasable —
+it targets the older `autosolve-foundations` API that `dev`'s merged hallucination layer
+replaced. Reuse it as the structural basis with a **bounded adaptation layer**:
+
+| Branch import | Status on `dev` | Adaptation |
+|---|---|---|
+| `hallucination_helpers.filter_with_checker` | absent (replaced by `MLChecker`) | call `checker(product, pathways) -> (status, kept)` where `checker = resolve_hallucination(mode, clf)` |
+| `hallucination_helpers.HallucinationPredictor` | absent | type as the checker `Callable`; drop the alias |
+| `utils.typing.HallucinationChecker` | absent | add alias `Callable[[str, list], tuple[int, list]]` |
+| `utils_molecule.canonicalize` | absent | port the trivial RDKit wrapper from foundations |
+| `run_az`, `llm_pipeline`, `format_output`, `recommend_reaction_metadata`, recommender types | present | no change |
+
+## 4. Architecture
+
+```
+deepretro/
+├── algorithms/autosolve.py     port AutoSolver (rewired) + reasoning_mode / tool_backend flags
+├── agents/                     NEW subpackage
+│   ├── __init__.py
+│   ├── tools.py                tool registry: schemas + executors + dispatcher
+│   ├── sandbox.py              subprocess sandbox behind a Sandbox protocol
+│   └── loop.py                 agentic_single_step() (full) + agentic_orchestrator() (scaffold)
+├── utils/utils_molecule.py     + canonicalize()
+└── utils/typing.py             + HallucinationChecker alias
+scripts/run_batch.py            NEW batch driver
+```
+
+### 4.1 `AutoSolver` flags (item: "both, flag-selectable")
+
+`AutoSolver.__init__` gains:
+
+- `reasoning_mode: {"pipeline", "single_step_agent", "orchestrator"} = "pipeline"`
+- `tool_backend: {"tools", "sandbox"} = "tools"`
+- `sandbox: Sandbox | None = None` (injectable; defaults to the subprocess backend)
+
+Behavior:
+
+- **`pipeline`** (default) — unchanged: `run_llm` calls `llm_pipeline`. Nothing is ripped out.
+- **`single_step_agent`** (fully built) — `run_llm`/`single_step` calls
+  `deepretro.agents.loop.agentic_single_step`, which lets the LLM call the tools to
+  self-correct its proposed precursors, then returns `(pathways, explanations, confidence)`
+  in the **same shape** `llm_pipeline` returns. The deterministic validity/stability/
+  hallucination filters still run afterward as a safety net — the agent's self-checks
+  augment, never replace, them.
+- **`orchestrator`** (scaffold, flag-wired, minimal impl) — `deepretro.agents.loop.agentic_orchestrator`
+  gives one agent tool-driven control of the whole search. Interface + wiring present;
+  `single_step_agent` is the deep implementation.
+
+The recursion in `solve()` is unchanged regardless of mode (§5).
+
+### 4.2 Tools (`agents/tools.py`)
+
+Ported/extended from `origin/agentic-solution:src/utils/tools.py`: Anthropic/litellm tool
+schema dicts + executor functions + a `TOOL_DEFINITIONS`/`TOOL_EXECUTORS` registry +
+`execute_tool(name, input) -> dict` dispatcher + `get_available_tools()`.
+
+| tool | signature | wraps | returns |
+|---|---|---|---|
+| `validate_smiles` | `(smiles, context?)` | `is_valid_smiles` + RDKit canonical | `{valid, canonical_smiles, error, context}` |
+| `check_stability` | `(smiles)` | `check_molecule_stability` | `{assessment, stability_score, issues}` |
+| `check_hallucination` | `(product, reactants)` | `resolve_hallucination`/`MLChecker` | **TEMPLATE**: `{configured: false, fallback_severity, note}` when no classifier; real verdict when one is injected. Flagged for the other contributor. |
+| `run_python` | `(code)` | `agents/sandbox.py` | `{ok, stdout, stderr, error}` — RDKit + `deepretro.algorithms` checkers importable |
+
+The tool registry is built once and passed into the agent loop; `check_hallucination`'s
+executor is bound to whatever `resolve_hallucination(mode, classifier)` returns so the ML
+classifier can be swapped in later without touching tool code.
+
+### 4.3 Sandbox (`agents/sandbox.py`) — subprocess backend
+
+```python
+class Sandbox(Protocol):
+    def run(self, code: str, *, timeout_s: float, mem_mb: int) -> SandboxResult: ...
+
+class SubprocessSandbox:  # default
+    # writes code to a temp file, runs `python <file>` in a subprocess with:
+    #   - resource.setrlimit(RLIMIT_AS, mem_mb) and RLIMIT_CPU (POSIX)
+    #   - a fresh temp cwd, cleaned up after
+    #   - captured stdout/stderr, hard wall-clock timeout (kill on expiry)
+    # returns SandboxResult(ok, stdout, stderr, error)
+```
+
+`ponytail:` comment marks the isolation ceiling — rlimit + no-inherited-fds is adequate for
+**LLM-generated, non-adversarial** chem code, but is **not** namespace/network isolation;
+upgrade path is a `PodmanSandbox` implementing the same `Sandbox` protocol if code ever
+becomes untrusted. Network is best-effort suppressed (cleared proxy env; documented ceiling).
+
+### 4.4 Agent loop (`agents/loop.py`)
+
+Ported/extended from `origin/agentic-solution:agentic_call_LLM`. Uses litellm's OpenAI-style
+tool calling through the existing `build_completion_params` seam:
+
+```python
+def agentic_single_step(
+    molecule, model, *, tools, tool_backend, max_iterations=6,
+    llm_runner=None, enable_thinking=True, max_output_tokens=None,
+) -> tuple[list[Pathway], list[str], list[float]]:
+    # loop: completion(**params, tools=tool_defs)
+    #   while finish_reason == "tool_use" / message.tool_calls and iter < max_iterations:
+    #       for each tool_call: execute_tool(...) -> append tool result message
+    #   on final answer: parse into (pathways, explanations, confidence)  [same shape as llm_pipeline]
+```
+
+`tool_backend="sandbox"` restricts the exposed tools to `run_python` (+ read-only checks);
+`tool_backend="tools"` exposes the structured check tools. `llm_runner` is injectable for tests
+(a fake returning a scripted `tool_use` then a final answer — no network). Iteration cap and
+per-tool error capture prevent runaway loops.
+
+## 5. Data flow (recursion terminates when AZ solves)
+
+```
+autosolve(smiles):
+    route_tree, solved = solve(smiles, depth=0, visited=set())
+    output = parse(route_tree)                 # format_output
+    output = add_metadata(output)              # recommend_reaction_metadata
+    return output, solved
+
+solve(molecule, depth, visited):
+    m = canonicalize(molecule)
+    if depth >= max_depth or m in visited:  return unsolved_leaf(m), False   # safety guards only
+    visited.add(m)
+    solved, routes = run_az(m, az_model)
+    if solved:  return az_route(routes), True          # ✅ AZ found building blocks → branch ends
+    # AZ could not solve → go deeper
+    pathways, expl, conf = single_step(m)              # pipeline OR agent, per reasoning_mode
+    pathways = validity / stability / hallucination filters
+    for pathway in pathways (best-first):
+        child_results = [solve(p, depth+1, visited) for p in pathway]
+        if all(child solved):  return assemble(pathway, child_results), True
+    return best_effort_partial, False
+```
+
+A branch stops **only** when AZ solves the node (purchasable/building-block leaf). A full
+pathway is solved iff every leaf bottoms out at an AZ-solved node. `max_depth`/cycle-detection
+are guards against infinite recursion when AZ never solves a path. This is exactly
+`src/rec_prithvi.py::rec_run_prithvi`'s behavior, preserved by `autosolve-pipeline::solve`.
+
+## 6. Batch script (`scripts/run_batch.py`)
+
+CLI:
+```
+python scripts/run_batch.py \
+  --sheet-url <google-sheets /export?format=csv URL>   # REQUIRED (public export, no auth)
+  --molecules <path/to/molecules.txt>                  # REQUIRED (one SMILES per line)
+  --out <output-dir> \
+  --reasoning-mode {pipeline,single_step_agent,orchestrator} \
+  --tool-backend {tools,sandbox} \
+  --model <litellm model id> \
+  --classifier <optional path to trained HallucinationClassifier> \
+  --top-k <int, default 3>
+```
+
+Steps:
+
+1. `download_sheet_csv(export_url, dest)` — plain `httpx`/`requests` GET on the
+   `/export?format=csv` URL (published/link-shared sheet, no auth). Fails loudly on non-200.
+2. `train_hallucination_checker(csv, out_dir)` — **TEMPLATE**: if the CSV has `product`/
+   `reactants`/`label`, run `ReactionDataLoader.create_dataset` → `stratified_split` →
+   `HallucinationClassifier.fit` → `.evaluate` → `.save`; return the saved path. If columns
+   are absent, log "template — supply a labeled CSV" and skip (batch still runs with the
+   heuristic hallucination mode). Clearly delimited for the other contributor.
+3. `read_molecules(txt)` — one SMILES per line; blank/`#`-comment lines skipped.
+4. Per molecule → **multiple routes**: take the top-K first-step candidate pathways the
+   LLM/agent proposes, solve each to completion, and write each as
+   `out/<timestamp>/<safe_molecule>/pathway_<i>.json`. `<timestamp>` is computed once at
+   startup (`YYYY-MM-DD_HH-MM-SS`); `<safe_molecule>` is a filesystem-safe slug of the SMILES.
+   Per-molecule failures write `error.json` and never abort the batch.
+
+**Multiple-pathways note:** the current `AutoSolver.solve` returns only the first fully-solved
+route (DFS). To satisfy the `pathway.json (multiple)` folder shape, the script drives the
+solver to emit the top-K candidate routes per molecule (via the first-level candidate
+pathways). This is additive; `solve`'s single-route contract is unchanged.
+
+## 7. Error handling
+
+- LLM/tool/sandbox failures degrade gracefully: status codes, `unsolved_leaf`, structured
+  sandbox errors, capped agent iterations. No exception escapes a single molecule's solve.
+- Batch: per-molecule `try/except` → `error.json`; the run continues.
+- Sandbox: wall-clock timeout kills the child; OOM/rlimit → structured error, not a crash.
+- Config: missing `--sheet-url`/`--molecules` → argparse error; missing API keys → clear message.
+
+## 8. Testing
+
+- `agents/tools.py`: each executor (valid/invalid SMILES, stability assessment,
+  hallucination template stub + injected-classifier verdict, `run_python` happy/error);
+  dispatcher unknown-tool path.
+- `agents/sandbox.py`: happy path, timeout kill, memory-cap trip, stderr capture,
+  temp-dir cleanup.
+- `agents/loop.py`: fake `llm_runner` scripting `tool_use` → final answer; asserts tools are
+  invoked, iteration cap respected, output shape matches `llm_pipeline`.
+- `algorithms/autosolve.py`: `reasoning_mode` wiring with injected `az_runner`/`llm_runner`
+  fakes (no network); recursion terminates on AZ-solve; `canonicalize` cycle detection.
+- `scripts/run_batch.py`: temp dirs + fake solver → verifies folder structure, top-K files,
+  `error.json` on failure; `download_sheet_csv` with a stubbed HTTP response.
+- `utils_molecule.canonicalize`: canonical-form + invalid input.
+
+Style: dependency injection + real pharmaceutical molecules (aspirin/paracetamol), **no
+monkeypatch/MagicMock** (matches the existing suite). Live-LLM tests marked `slow`/skippable.
+`uv run pytest`; `ruff check`/`ruff format`; `ty`; numpydoc docstrings with usage examples.
+
+## 9. Non-goals / templates
+
+- **Hallucination trained-model wiring** — `check_hallucination` tool + `train_hallucination_checker`
+  are templates; another contributor completes them. The heuristic path remains fully functional.
+- **Google auth** — none; public CSV export URL only.
+- **Top-level orchestrator** — scaffolded + flag-wired, minimal impl; `single_step_agent` is
+  the fully-built agent mode.
+- **Podman/remote sandbox** — protocol seam only; subprocess backend ships.
+- No changes to the Flask API / `src/` tree; no changes to the default `pipeline` behavior.
+
+## 10. Required inputs still needed from the user
+
+- The Google Sheets `/export?format=csv` URL.
+- The path to the molecules `.txt` file (and confirmation of one-SMILES-per-line format).
+
+Both are wired as required CLI args with placeholders + TODO so the script is runnable the
+moment they are supplied; their absence does not block implementation or tests.
+
+## 11. Process
+
+Spec → **4-persona review** (Codex, adversarial reviewer, senior open-source dev, senior
+engineer) → revise → implement (TDD) → PR to `dev` (no Claude co-author).

--- a/scripts/run_batch.py
+++ b/scripts/run_batch.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""CLI entry point for the DeepRetro batch retrosynthesis runner.
+
+Thin wrapper around :func:`deepretro.batch.main` so the pipeline logic stays
+importable and unit-tested. Example:
+
+    python scripts/run_batch.py \\
+        --sheet-url "https://docs.google.com/spreadsheets/d/<ID>/export?format=csv&gid=<GID>" \\
+        --molecules molecules.txt \\
+        --out batch_output \\
+        --solve-mode single_step_agent \\
+        --tool-backend sandbox
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running as a plain script (python scripts/run_batch.py) without an
+# installed package: put the repo root on sys.path so ``deepretro`` imports.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from deepretro.batch import main  # noqa: E402  (after sys.path bootstrap)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adapts DeepRetro's recursive retrosynthesis algorithm to run as an **agentic loop with tool calling**, inside the `deepretro/` package, plus a batch runner.

Builds on the unmerged `origin/autosolve-pipeline` AutoSolver, rewired to current `dev` APIs and extended. A written design spec was produced first and reviewed by four independent personas (Codex + adversarial + senior OSS maintainer + senior engineer); all blockers/majors from that review are incorporated. Spec: `docs/superpowers/specs/2026-07-01-agentic-autosolve-design.md`.

## Highlights

- **`deepretro/algorithms/autosolve.py`** — recursive AZ + LLM solver. AZ is tried first at every node; on a miss the LLM/agent proposes precursors that are recursively solved **until AZ solves each leaf**. Per-branch visited-set copy for cycle detection.
  - `solve_mode ∈ {pipeline (default), single_step_agent, orchestrator}`, `tool_backend ∈ {structured, sandbox}`. `orchestrator` raises `NotImplementedError` (scaffold; not offered in the CLI).
  - `run_llm` is the **single owner** of validity/stability/hallucination filtering, so the agent path can never bypass the safety net; `llm_pipeline`'s internal hallucination pass is disabled to avoid a double filter.
  - `solve_multiple(k)` — top-K candidate routes, each with a fresh visited set, for the batch runner's multiple `pathway.json` outputs.
  - AZ runner exceptions (missing models etc.) degrade to an unsolved leaf.
- **`deepretro/agents/`** (new)
  - `tools.py` — OpenAI function-format schemas + executors + dispatcher: `validate_smiles`, `check_stability`, `check_hallucination` (template seam bound to the resolved checker; omitted when none), `run_python`.
  - `sandbox.py` — `SubprocessSandbox` behind a `Sandbox` protocol: **secret-scrubbed env** (no API keys inherited), POSIX rlimits (`AS`/`CPU`/`NPROC`/`FSIZE`, `AS` floored above the RDKit import footprint), wall-clock timeout with process-group kill, best-effort `unshare -rn` network isolation on Linux. Documented ceiling + Podman upgrade path.
  - `loop.py` — `agentic_single_step` runs a litellm tool-calling loop (injectable model call; `enable_thinking` off by default for multi-turn tool use; iteration cap → empty → unsolved leaf) and returns `llm_pipeline`'s output shape. `agentic_orchestrator` raises `NotImplementedError`.
- **Adaptation layer** — `utils_molecule.canonicalize`, `utils.typing.HallucinationChecker`, and `hallucination_helpers.filter_with_checker` (realigns explanations/confidence to kept pathways — fixes the index-misalignment the review flagged).
- **`deepretro/batch.py` + `scripts/run_batch.py`** — download a public Google-Sheet CSV → (template) train the hallucination checker → run molecules from a `.txt` file → dump `<out>/<timestamp>/<molecule>/pathway_<i>.json`; per-molecule `error.json` backstop.

## Tests

TDD throughout, dependency injection + real pharmaceutical molecules, no monkeypatch/MagicMock. **Full suite: 275 passed, 2 skipped** (Linux-only memory-cap test), 6 slow-deselected. `ruff` and `ty` clean; numpydoc docstrings with doctests. End-to-end batch smoke with a real `AutoSolver` produces the folder tree.

## Templates / inputs still needed

- **Hallucination model wiring** — the `check_hallucination` ML path and `train_hallucination_checker` are templates for a downstream contributor; the heuristic path is fully functional throughout.
- **Batch inputs** — `--sheet-url` (public `/export?format=csv`) and `--molecules` are required CLI args with placeholders + TODO; supply them to run end-to-end.

## Notes

- The default non-agentic `pipeline` behavior is unchanged; the agent path is additive and flag-gated.
- Reviewers suggested stacked PRs; kept as one PR to `dev` per request, organized as logically-ordered commits (adaptation → AutoSolver → agents → batch).