### PR TITLE
enable extended thinking for Claude models

### DIFF
--- a/.github/workflows/deepretro_lint.yml
+++ b/.github/workflows/deepretro_lint.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     paths:
       - ".github/workflows/deepretro_lint.yml"
       - "deepretro/**"
   push:
     branches:
       - main
+      - dev
     paths:
       - ".github/workflows/deepretro_lint.yml"
       - "deepretro/**"

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - "docs/**"
       - "deepretro/**"
@@ -11,6 +12,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     paths:
       - "docs/**"
       - "deepretro/**"

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
 
 jobs:
   viewer-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
 
 jobs:
   test:

--- a/deepretro/agents/sandbox.py
+++ b/deepretro/agents/sandbox.py
@@ -47,26 +47,19 @@ _MIN_ADDRESS_SPACE_MB = 1024
 class SandboxResult:
     """Outcome of one sandboxed execution.
 
-    Attributes
-    ----------
-    ok : bool
-        ``True`` when the code exited with status 0 within limits.
-    stdout : str
-        Captured standard output.
-    stderr : str
-        Captured standard error (traceback on failure).
-    error : str
-        Sandbox-level error (e.g. a timeout message); empty on success.
-
     Examples
     --------
     >>> SandboxResult(ok=True, stdout="hi\\n", stderr="", error="").ok
     True
     """
 
+    #: ``True`` when the code exited with status 0 within limits.
     ok: bool
+    #: Captured standard output.
     stdout: str
+    #: Captured standard error (traceback on failure).
     stderr: str
+    #: Sandbox-level error (e.g. a timeout message); empty on success.
     error: str
 
 

--- a/deepretro/agents/sandbox.py
+++ b/deepretro/agents/sandbox.py
@@ -47,19 +47,26 @@ _MIN_ADDRESS_SPACE_MB = 1024
 class SandboxResult:
     """Outcome of one sandboxed execution.
 
+    Attributes
+    ----------
+    ok : bool
+        ``True`` when the code exited with status 0 within limits.
+    stdout : str
+        Captured standard output.
+    stderr : str
+        Captured standard error (traceback on failure).
+    error : str
+        Sandbox-level error (e.g. a timeout message); empty on success.
+
     Examples
     --------
     >>> SandboxResult(ok=True, stdout="hi\\n", stderr="", error="").ok
     True
     """
 
-    #: ``True`` when the code exited with status 0 within limits.
     ok: bool
-    #: Captured standard output.
     stdout: str
-    #: Captured standard error (traceback on failure).
     stderr: str
-    #: Sandbox-level error (e.g. a timeout message); empty on success.
     error: str
 
 

--- a/deepretro/agents/tools.py
+++ b/deepretro/agents/tools.py
@@ -29,13 +29,6 @@ ToolExecutor = Callable[..., dict[str, Any]]
 class ToolRegistry:
     """Bundle of LiteLLM tool schemas and their executors.
 
-    Attributes
-    ----------
-    schemas : list[dict]
-        OpenAI function-format tool definitions to pass to ``completion``.
-    executors : dict[str, ToolExecutor]
-        Mapping from tool name to its executor callable.
-
     Examples
     --------
     >>> registry = build_tool_registry()
@@ -43,7 +36,9 @@ class ToolRegistry:
     'CCO'
     """
 
+    #: OpenAI function-format tool definitions to pass to ``completion``.
     schemas: list[dict[str, Any]]
+    #: Mapping from tool name to its executor callable.
     executors: dict[str, ToolExecutor]
 
     @property

--- a/deepretro/agents/tools.py
+++ b/deepretro/agents/tools.py
@@ -29,6 +29,13 @@ ToolExecutor = Callable[..., dict[str, Any]]
 class ToolRegistry:
     """Bundle of LiteLLM tool schemas and their executors.
 
+    Attributes
+    ----------
+    schemas : list[dict]
+        OpenAI function-format tool definitions to pass to ``completion``.
+    executors : dict[str, ToolExecutor]
+        Mapping from tool name to its executor callable.
+
     Examples
     --------
     >>> registry = build_tool_registry()
@@ -36,9 +43,7 @@ class ToolRegistry:
     'CCO'
     """
 
-    #: OpenAI function-format tool definitions to pass to ``completion``.
     schemas: list[dict[str, Any]]
-    #: Mapping from tool name to its executor callable.
     executors: dict[str, ToolExecutor]
 
     @property

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -177,6 +177,7 @@ def call_LLM(molecule: str,
         "seed": 42,
         "top_p": 0.9,
         "metadata": get_langfuse_metadata("retrosynthesis"),
+        "drop_params": True,
     }
 
     if LLM in DEEPSEEK_MODELS:
@@ -187,10 +188,18 @@ def call_LLM(molecule: str,
         params["temperature"] = 1
         params.pop("top_p", None)
         params.pop("max_completion_tokens", None)
-        params['thinking'] = {
-            "type": "enabled",
-            "budget_tokens": EXTENDED_THINKING_BUDGET_TOKENS
-        }
+        try:
+            is_adaptive_thinking_model = bool(
+                litellm.get_model_info(LLM).get("supports_adaptive_thinking"))
+        except Exception:
+            is_adaptive_thinking_model = False
+        if is_adaptive_thinking_model:
+            params['thinking'] = {"type": "adaptive"}
+        else:
+            params['thinking'] = {
+                "type": "enabled",
+                "budget_tokens": EXTENDED_THINKING_BUDGET_TOKENS
+            }
 
     if messages is None:
         messages = [{

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -11,6 +11,9 @@ from src.variables import USER_PROMPT_OPENAI, SYS_PROMPT_OPENAI
 from src.variables import USER_PROMPT_DEEPSEEK, SYS_PROMPT_DEEPSEEK
 from src.variables import ADDON_PROMPT_7_MEMBER, USER_PROMPT_DEEPSEEK_V4
 from src.variables import ERROR_MAP, PROTECTING_GROUP_CONTEXT
+from src.variables import CLAUDE_EXTENDED_THINKING_MODELS
+from src.variables import EXTENDED_THINKING_BUDGET_TOKENS
+from src.variables import EXTENDED_THINKING_MAX_TOKENS
 from src.cache import cache_results
 from src.utils.utils_molecule import validity_check, detect_seven_member_rings
 from src.utils.job_context import logger as context_logger
@@ -48,6 +51,26 @@ def log_message(message: str, logger=None):
         logger.info(message)
     else:
         print(message)
+
+
+def supports_extended_thinking(LLM: str) -> bool:
+    """Check whether the model supports Anthropic extended thinking.
+
+    Parameters
+    ----------
+    LLM : str
+        The LLM model identifier, possibly with a provider prefix
+        (e.g. "anthropic/claude-sonnet-4-20250514") and/or an ":adv"
+        advanced-prompt suffix.
+
+    Returns
+    -------
+    bool
+        True if extended thinking should be enabled for this model
+    """
+    model_name = LLM.split("/")[-1].split(":")[0]
+    return any(known in model_name
+               for known in CLAUDE_EXTENDED_THINKING_MODELS)
 
 
 def obtain_prompt(LLM: str):
@@ -159,12 +182,15 @@ def call_LLM(molecule: str,
     if LLM in DEEPSEEK_MODELS:
         user_prompt_final += add_on
 
-    if "3-7" in LLM:
-        params["max_tokens"] = 13192 + 5000
+    if supports_extended_thinking(LLM):
+        params["max_tokens"] = EXTENDED_THINKING_MAX_TOKENS
         params["temperature"] = 1
         params.pop("top_p", None)
         params.pop("max_completion_tokens", None)
-        params['thinking'] = {"type": "enabled", "budget_tokens": 5000}
+        params['thinking'] = {
+            "type": "enabled",
+            "budget_tokens": EXTENDED_THINKING_BUDGET_TOKENS
+        }
 
     if messages is None:
         messages = [{

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -122,7 +122,7 @@ def obtain_prompt(LLM: str):
 
 @cache_results
 def call_LLM(molecule: str,
-             LLM: str = "claude-opus-4-20250514",
+             LLM: str = "claude-opus-4-8",
              temperature: float = 0.0,
              messages: Optional[list[dict]] = None,
              use_protecting_group_feature: bool = False) -> tuple[int, str]:
@@ -133,7 +133,7 @@ def call_LLM(molecule: str,
     molecule : str
         The target molecule for retrosynthesis
     LLM : str, optional
-        The LLM model to be used, by default "claude-opus-4-20250514"
+        The LLM model to be used, by default "claude-opus-4-8"
     temperature : float, optional
         The temperature for sampling, by default 0.0
     messages : Optional[list[dict]], optional

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -189,7 +189,7 @@ def call_LLM(molecule: str,
         params.pop("top_p", None)
         params.pop("max_completion_tokens", None)
         try:
-            is_adaptive_thinking_model = bool(
+            is_adaptive_thinking_model = "claude-opus-4-8" in LLM or bool(
                 litellm.get_model_info(LLM).get("supports_adaptive_thinking"))
         except Exception:
             is_adaptive_thinking_model = False

--- a/src/variables.py
+++ b/src/variables.py
@@ -1361,6 +1361,21 @@ DEEPSEEK_MODELS = [
     "together_ai/deepseek-ai/DeepSeek-R1"
 ]
 
+# Anthropic models that support extended thinking. Matched as substrings of
+# the model name (provider prefixes like "anthropic/" and suffixes like
+# ":adv" are stripped first), so date-stamped variants and future point
+# releases (e.g. claude-opus-4-1-*) match without editing this list.
+CLAUDE_EXTENDED_THINKING_MODELS = [
+    "claude-3-7-sonnet",
+    "claude-opus-4",
+    "claude-sonnet-4",
+]
+
+# Anthropic requires max_tokens > budget_tokens when thinking is enabled;
+# 13192 is the pre-existing completion allowance, budget rides on top.
+EXTENDED_THINKING_BUDGET_TOKENS = 5000
+EXTENDED_THINKING_MAX_TOKENS = 13192 + EXTENDED_THINKING_BUDGET_TOKENS
+
 ERROR_MAP = {
     200: {
         "description": "SUCCESS",

--- a/src/variables.py
+++ b/src/variables.py
@@ -1361,18 +1361,12 @@ DEEPSEEK_MODELS = [
     "together_ai/deepseek-ai/DeepSeek-R1"
 ]
 
-# Anthropic models that support extended thinking. Matched as substrings of
-# the model name (provider prefixes like "anthropic/" and suffixes like
-# ":adv" are stripped first), so date-stamped variants and future point
-# releases (e.g. claude-opus-4-1-*) match without editing this list.
 CLAUDE_EXTENDED_THINKING_MODELS = [
     "claude-3-7-sonnet",
     "claude-opus-4",
     "claude-sonnet-4",
 ]
 
-# Anthropic requires max_tokens > budget_tokens when thinking is enabled;
-# 13192 is the pre-existing completion allowance, budget rides on top.
 EXTENDED_THINKING_BUDGET_TOKENS = 5000
 EXTENDED_THINKING_MAX_TOKENS = 13192 + EXTENDED_THINKING_BUDGET_TOKENS
 

--- a/tests/variables_test.py
+++ b/tests/variables_test.py
@@ -2,9 +2,9 @@
 VALID_SMILE_STRING = 'CC(=O)CC'
 
 # Claude model
-CLAUDE_MODEL = "claude-opus-4-20250514"
+CLAUDE_MODEL = "claude-opus-4-8"
 
-CLAUDE_ADV_MODEL = "claude-opus-4-20250514:adv"
+CLAUDE_ADV_MODEL = "claude-opus-4-8:adv"
 
 # OpenAI model
 OPENAI_MODEL = "gpt-4o"


### PR DESCRIPTION
Extended thinking was gated behind 'if "3-7" in LLM', so only claude-3-7-sonnet ever received the thinking params and the current default silently ran without extended thinking.

Additional CI Changes were made.

## Description

Fix #(issue)

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings