### PR TITLE
Run CI workflows on dev, not just main

### DIFF
--- a/.github/workflows/deepretro_lint.yml
+++ b/.github/workflows/deepretro_lint.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     paths:
       - ".github/workflows/deepretro_lint.yml"
       - "deepretro/**"
   push:
     branches:
       - main
+      - dev
     paths:
       - ".github/workflows/deepretro_lint.yml"
       - "deepretro/**"

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - "docs/**"
       - "deepretro/**"
@@ -11,6 +12,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     paths:
       - "docs/**"
       - "deepretro/**"

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
 
 jobs:
   viewer-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- All four workflows (unit tests, deepretro lint/type-check, docs build, frontend tests) only trigger on `push`/`pull_request` to `main`.
- Every currently open PR targets `dev`, so none of them have ever had a single CI check run.
- Adds `dev` alongside `main` in each workflow's `branches:` filter. No other behavior changes.