### PR TITLE
Fix dev CI: lint, type-check, and docs build failures

### DIFF
--- a/deepretro/algorithms/autosolve.py
+++ b/deepretro/algorithms/autosolve.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import Callable, Sequence
-from typing import Any, Optional
+from typing import Any
 
 import structlog
 
@@ -24,7 +24,6 @@ from deepretro.metadata_types import (
 )
 from deepretro.models.hallucination_helpers import (
     filter_with_checker,
-    resolve_hallucination,
 )
 from deepretro.utils.az import run_az
 from deepretro.utils.llm_helpers import Pathway
@@ -158,8 +157,7 @@ class AutoSolver:
         self.stability_check = stability_check
         self.hallucination_mode = hallucination_mode.lower()
         self.hallucination_checker = HallucinationChecker(
-            checker_type=self.hallucination_mode,
-            model_path=hallucination_classifier
+            checker_type=self.hallucination_mode, model_path=hallucination_classifier
         )
         self.solve_mode = solve_mode
         self.tool_backend = tool_backend

--- a/deepretro/featurizers/reactionstep.py
+++ b/deepretro/featurizers/reactionstep.py
@@ -1,10 +1,19 @@
 """DeepChem-compatible featurizer for reaction-step (product + reactants) pairs."""
 
+from __future__ import annotations
+
 import numpy as np
 import deepchem as dc
+import deepchem.feat  # noqa: F401  # ensure ``dc.feat`` submodule is registered
 from deepchem.feat.graph_data import GraphData
 from deepretro.utils import extract_domain_features_single
-from typing import Any, Tuple
+from typing import Any, Callable, Dict, Tuple, TypedDict
+
+# ``class`` is a Python keyword, so this TypedDict uses the functional syntax.
+FeaturizerConfig = TypedDict(
+    "FeaturizerConfig",
+    {"class": Callable[..., Any], "type": str, "default_params": Dict[str, Any]},
+)
 
 
 class ReactionStepFeaturizer(dc.feat.Featurizer):
@@ -13,14 +22,14 @@ class ReactionStepFeaturizer(dc.feat.Featurizer):
 
     Each datapoint is represented as a tuple of ``(product_smiles, reactants_smiles)``.
 
-    The featurizer wraps a DeepChem molecular featurizer and applies it to both the product and reactant molecules. 
+    The featurizer wraps a DeepChem molecular featurizer and applies it to both the product and reactant molecules.
     Depending on the selected base featurizer, the output is either:
 
-    * **Vector-based features** (e.g. CircularFingerprint): product and reactant feature vectors are concatenated. 
-    Optional reaction-level domain features can also be appended.
+    * **Vector-based features** (e.g. CircularFingerprint): product and reactant feature vectors are concatenated.
+      Optional reaction-level domain features can also be appended.
 
     * **Graph-based features** (e.g. MolGraphConvFeaturizer): product and reactant SMILES are combined into a single
-    molecular graph representation.
+      molecular graph representation.
 
     Parameters
     ----------
@@ -31,7 +40,7 @@ class ReactionStepFeaturizer(dc.feat.Featurizer):
         Whether to append handcrafted reaction-level domain features when using circular fingerprints. default=True
 
     **kwargs
-        Additional keyword arguments passed to the underlying DeepChem featurizer. These override any defaults defined 
+        Additional keyword arguments passed to the underlying DeepChem featurizer. These override any defaults defined
         in ``FEATURIZER_MAP``.
 
     Raises
@@ -40,10 +49,12 @@ class ReactionStepFeaturizer(dc.feat.Featurizer):
         If ``base_featurizer`` is not present in ``FEATURIZER_MAP``.
     """
 
-    def __init__(self, 
-                base_featurizer: str ="circularfingerprint", 
-                use_domain_features: bool = False, 
-                **kwargs: Any) -> None:
+    def __init__(
+        self,
+        base_featurizer: str = "circularfingerprint",
+        use_domain_features: bool = False,
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize the reaction-step featurizer.
 
@@ -54,24 +65,28 @@ class ReactionStepFeaturizer(dc.feat.Featurizer):
         use_domain_features: bool
             controls whether reaction-level domain features are appended for fingerprint-based features. default = False
         **kwargs
-            Parameters passed to the selected base featurizer. The special argument ``use_domain_features`` 
+            Parameters passed to the selected base featurizer. The special argument ``use_domain_features``
         """
         # Extract use_domain_features safely from kwargs with a standard True fallback
         self.use_domain_features = use_domain_features
-        
+
         feat_lower = base_featurizer.lower()
         if feat_lower not in FEATURIZER_MAP:
-            raise ValueError(f"Inner base featurizer '{base_featurizer}' not found in FEATURIZER_MAP.")
-            
+            raise ValueError(
+                f"Inner base featurizer '{base_featurizer}' not found in FEATURIZER_MAP."
+            )
+
         config = FEATURIZER_MAP[feat_lower]
         self.base_feat_type = config["type"]
-        
+
         # Combine default config parameters with remaining explicit user overrides
         merged_params = config["default_params"].copy()
         merged_params.update(kwargs)
         self.base_featurizer = config["class"](**merged_params)
 
-    def _featurize(self, datapoint: Tuple[str, str], **kwargs: Any) -> np.ndarray | GraphData:
+    def _featurize(
+        self, datapoint: Tuple[str, str], **kwargs: Any
+    ) -> np.ndarray | GraphData:
         """
         Featurize a single reaction step.
 
@@ -92,59 +107,63 @@ class ReactionStepFeaturizer(dc.feat.Featurizer):
             Feature representation of the reaction step.
 
             For vector-based featurizers, returns a concatenated feature vector consisting of:
-            ``[product_features, reactant_features, domain_features]``, where domain features are included only 
+            ``[product_features, reactant_features, domain_features]``, where domain features are included only
             when enabled and supported.
 
-            For graph-based featurizers, returns a graph representation generated from the combined product and 
+            For graph-based featurizers, returns a graph representation generated from the combined product and
             reactant SMILES.
 
         Notes
         -----
-        Invalid molecules are handled by DeepChem's parent ``Featurizer.featurize()`` implementation. If either 
+        Invalid molecules are handled by DeepChem's parent ``Featurizer.featurize()`` implementation. If either
         the product or reactant featurization fails for vector-based featurizers, an empty NumPy array is returned.
         """
         product_smiles, reactants_smiles = datapoint
-        
+
         if self.base_feat_type == "1d_vector":
             # --- 1D VECTOR ROUTE (Fingerprints, Descriptors) ---
             prod_feats = self.base_featurizer.featurize(product_smiles, **kwargs)[0]
-            
+
             if prod_feats.size == 0:
                 return np.array([])
-                
+
             reac_feats = self.base_featurizer.featurize(reactants_smiles, **kwargs)[0]
             if reac_feats.size == 0:
                 return np.array([])
-                
+
             parts = [prod_feats, reac_feats]
-            
+
             # Append domain chemistry metrics only for ECFP calculations
-            if self.use_domain_features and isinstance(self.base_featurizer, dc.feat.CircularFingerprint):
+            if self.use_domain_features and isinstance(
+                self.base_featurizer, dc.feat.CircularFingerprint
+            ):
                 parts.append(
                     extract_domain_features_single(product_smiles, reactants_smiles)
                 )
             return np.concatenate(parts)
-            
+
         elif self.base_feat_type == "graph":
             # --- GRAPH ROUTE (MolGraphConv, DMPNN) ---
             combined_smiles = f"{product_smiles}.{reactants_smiles}"
             return self.base_featurizer.featurize(combined_smiles, **kwargs)[0]
 
+        raise ValueError(f"Unsupported base featurizer type: '{self.base_feat_type}'.")
 
-FEATURIZER_MAP = {
+
+FEATURIZER_MAP: Dict[str, FeaturizerConfig] = {
     "molgraphconv": {
         "class": dc.feat.MolGraphConvFeaturizer,
         "type": "graph",
-        "default_params": {}
+        "default_params": {},
     },
     "circularfingerprint": {
         "class": dc.feat.CircularFingerprint,
         "type": "1d_vector",
-        "default_params": {"radius": 2, "size": 2048}
+        "default_params": {"radius": 2, "size": 2048},
     },
     "reactionfeaturizer": {
         "class": ReactionStepFeaturizer,
-        "type": "composite", 
-        "default_params": {}
-    }
+        "type": "composite",
+        "default_params": {},
+    },
 }

--- a/deepretro/models/hallucination_checker.py
+++ b/deepretro/models/hallucination_checker.py
@@ -2,21 +2,25 @@ import os
 import json
 import numpy as np
 import deepchem as dc
-from typing import Tuple, Dict, List
+from typing import Tuple, List
 from deepretro.models.hallucination_utils import create_model_instance
 from deepretro.featurizers.reactionstep import FEATURIZER_MAP
-from deepretro.algorithms.pipeline_checks import hallucination_checker as heuristic_checker
+from deepretro.algorithms.pipeline_checks import (
+    hallucination_checker as heuristic_checker,
+)
+
 
 class HallucinationChecker:
     """
-    Inference infrastructure for detecting pathway hallucinations using either rule-based heuristics or unified 
+    Inference infrastructure for detecting pathway hallucinations using either rule-based heuristics or unified
     machine learning models.
     """
-    
-    def __init__(self,
-                checker_type: str = "ml",
-                model_path: str | None = None,
-                ) -> None:
+
+    def __init__(
+        self,
+        checker_type: str = "ml",
+        model_path: str | None = None,
+    ) -> None:
         """
         Initializes a hallucination checker.
 
@@ -33,18 +37,22 @@ class HallucinationChecker:
         self.featurizer: dc.feat.Featurizer | None = None
         self.threshold: float = 0.5
         self.model_type: str | None = None
-        
+
         if self.checker_type not in ["heuristic", "ml"]:
-            raise ValueError(f"Unknown checker_type: {self.checker_type}. Allowed: 'heuristic', 'ml'")
-            
+            raise ValueError(
+                f"Unknown checker_type: {self.checker_type}. Allowed: 'heuristic', 'ml'"
+            )
+
         if self.checker_type == "ml":
             if self.model_path is None:
-                raise ValueError("A valid 'model_path' must be provided when checker_type is 'ml'.")
+                raise ValueError(
+                    "A valid 'model_path' must be provided when checker_type is 'ml'."
+                )
             self.load_model(self.model_path)
 
     def load_model(self, model_path: str) -> None:
         """
-        Loads the saved trainer configuration, instantiates the required underlying featurizers, and restores 
+        Loads the saved trainer configuration, instantiates the required underlying featurizers, and restores
         model weights from disk.
 
         Parameters
@@ -52,38 +60,42 @@ class HallucinationChecker:
         model_path : str
             Path to the saved model directory.
         """
-        config_path = os.path.join(model_path, 'config.json')
+        config_path = os.path.join(model_path, "config.json")
         if not os.path.exists(config_path):
-            raise FileNotFoundError(f"No config.json file found in model path: {model_path}")
-            
-        with open(config_path, 'r') as f:
+            raise FileNotFoundError(
+                f"No config.json file found in model path: {model_path}"
+            )
+
+        with open(config_path, "r") as f:
             config = json.load(f)
-            
+
         # Extract metadata directly from the saved JSON configuration
-        self.model_type = config.get('model_type')
-        model_params = config.get('model_params', {})
-        feat_name = config.get('feat_name')
-        feat_params = config.get('feat_params', {})
-        self.threshold = config.get('threshold', 0.5)
-        n_tasks = config.get('n_tasks', 1)
-        
+        self.model_type = config.get("model_type")
+        model_params = config.get("model_params", {})
+        feat_name = config.get("feat_name")
+        feat_params = config.get("feat_params", {})
+        self.threshold = config.get("threshold", 0.5)
+        n_tasks = config.get("n_tasks", 1)
+
         print(f"Restoring saved {self.model_type.upper()} pipeline from disk...")
         print(f"Loaded Decision Threshold: {self.threshold:.4f}")
-        
+
         # 1. Dynamically initialize the custom operational featurizer wrapper
         if feat_name.lower() not in FEATURIZER_MAP:
-            raise ValueError(f"Saved featurizer '{feat_name}' is not registered in FEATURIZER_MAP.")
-            
+            raise ValueError(
+                f"Saved featurizer '{feat_name}' is not registered in FEATURIZER_MAP."
+            )
+
         feat_config = FEATURIZER_MAP[feat_name.lower()]
         merged_feat_params = feat_config["default_params"].copy()
         merged_feat_params.update(feat_params)
         self.featurizer = feat_config["class"](**merged_feat_params)
-        
+
         # 2. Package parameters and construct the model instance using our standalone factory
         params = model_params.copy()
-        params['model_dir'] = model_path
-        params['n_tasks'] = n_tasks
-        
+        params["model_dir"] = model_path
+        params["n_tasks"] = n_tasks
+
         self.model = create_model_instance(self.model_type, **params)
         try:
             self.model.restore()
@@ -92,38 +104,35 @@ class HallucinationChecker:
 
     def check_single_pathway(self, target: str, reactants: str) -> int:
         """
-        Public inference API route. Accepts a single pathway definition step 
+        Public inference API route. Accepts a single pathway definition step
         and routes it to the designated heuristic or ML backend processor.
-        
+
         Parameters
         ----------
         target : str
             SMILES representation of the target molecule (product).
         reactants : str
             SMILES representation of the reactant molecules (dot-separated).
-            
+
         Returns
         -------
         int
             Binary prediction: 1 if it's a hallucination, 0 if it's a valid step.
         """
         if self.checker_type == "heuristic":
-          _, valid_pathways = self._check_pathway_heur(target, [reactants])
-          return 0 if len(valid_pathways) > 0 else 1
+            _, valid_pathways = self._check_pathway_heur(target, [reactants])
+            return 0 if len(valid_pathways) > 0 else 1
         else:
             return self._check_pathway_ml(target, reactants)
 
-    def __call__(self, target: str,
-                       pathways: List[str] | List[List[str]]):
-        return self.check_pathways(
-                       target,
-                       pathways)
-        
+    def __call__(self, target: str, pathways: List[str] | List[List[str]]):
+        return self.check_pathways(target, pathways)
 
-    def check_pathways(self, 
-                       target: str,
-                       pathways: List[str] | List[List[str]],
-                    ) -> Tuple[int, List]:
+    def check_pathways(
+        self,
+        target: str,
+        pathways: List[str] | List[List[str]],
+    ) -> Tuple[int, List]:
         """
         Filters a collection of candidate pathways.
 
@@ -160,11 +169,12 @@ class HallucinationChecker:
 
             return 200, valid_pathways
 
-    def _check_pathway_heur(self,
-                            target: str,
-                            reactants: List[str] | str,
-                        ) -> Tuple[int, List]:
-        """ Evaluates pathways using deterministic chemical heuristics.
+    def _check_pathway_heur(
+        self,
+        target: str,
+        reactants: List[str] | str,
+    ) -> Tuple[int, List]:
+        """Evaluates pathways using deterministic chemical heuristics.
 
         Parameters
         ----------
@@ -200,15 +210,19 @@ class HallucinationChecker:
         """
         datapoint = (target, reactants)
         features = self.featurizer.featurize([datapoint])
-        
+
         # Check if featurization completely failed natively inside DeepChem
-        if features.size == 0 or (isinstance(features[0], np.ndarray) and features[0].size == 0):
-            print("Warning: Featurization failed on input strings. Marking as hallucination by default.")
+        if features.size == 0 or (
+            isinstance(features[0], np.ndarray) and features[0].size == 0
+        ):
+            print(
+                "Warning: Featurization failed on input strings. Marking as hallucination by default."
+            )
             return 1
 
         dataset = dc.data.NumpyDataset(X=features)
         y_pred = self.model.predict(dataset)
-        
+
         # Isolate raw positive-class scalar probabilities across Sklearn vs. GNN shape spaces
         if len(y_pred.shape) == 3 and y_pred.shape[2] == 2:
             prob = y_pred[0, 0, 1]

--- a/deepretro/models/hallucination_trainer.py
+++ b/deepretro/models/hallucination_trainer.py
@@ -3,10 +3,18 @@ import json
 import shutil
 import numpy as np
 import deepchem as dc
-from deepchem.feat.graph_data import GraphData
 from deepretro.featurizers.reactionstep import FEATURIZER_MAP
-from deepretro.models.hallucination_utils import MODEL_CONFIGS, create_model_instance, KFoldRandomHyperparamOpt
-from sklearn.metrics import precision_recall_curve, accuracy_score, precision_score, recall_score
+from deepretro.models.hallucination_utils import (
+    MODEL_CONFIGS,
+    create_model_instance,
+    KFoldRandomHyperparamOpt,
+)
+from sklearn.metrics import (
+    precision_recall_curve,
+    accuracy_score,
+    precision_score,
+    recall_score,
+)
 from deepretro.data.loader import ReactionDataLoader
 from typing import Any, Optional, Dict, Tuple, List
 
@@ -15,12 +23,14 @@ class HallucinationTrainer:
     """
     A DeepChem-based ML infrastructure for training models to detect hallucinations.
     """
-    
-    def __init__(self, 
-                trainer_dir: str,
-                n_tasks: int = 1,
-                model_type: Optional[str] = None, 
-                model_path: Optional[str] = None) -> None:
+
+    def __init__(
+        self,
+        trainer_dir: str,
+        n_tasks: int = 1,
+        model_type: Optional[str] = None,
+        model_path: Optional[str] = None,
+    ) -> None:
         """
         Initializes a hallucination trainer.
 
@@ -37,7 +47,7 @@ class HallucinationTrainer:
         """
         self.trainer_dir = trainer_dir
         os.makedirs(self.trainer_dir, exist_ok=True)
-        
+
         # Initialize attributes
         self.model_type = None
         self.model_params = {}
@@ -45,30 +55,30 @@ class HallucinationTrainer:
         self.threshold = 0.5
         self.param_space = {}
         self.model_dir = None
-        self.model = None 
+        self.model = None
         self.n_tasks = n_tasks
         self.featurizer = None
         self.feat_params = None
-        
+
         if model_path is not None:
-            config_path = os.path.join(model_path, 'config.json')
+            config_path = os.path.join(model_path, "config.json")
             if not os.path.exists(config_path):
                 raise FileNotFoundError(f"No config.json found in {model_path}")
-                
-            with open(config_path, 'r') as f:
+
+            with open(config_path, "r") as f:
                 config = json.load(f)
-                
-            self.model_type = config.get('model_type')
-            self.model_params = config.get('model_params', {})
-            self.feat_name = config.get('feat_name')
-            self.feat_params = config.get('feat_params', {})
-            self.threshold = config.get('threshold', 0.5)
-            self.param_space = config.get('param_space', {}) 
-            self.n_tasks = config.get('n_tasks', self.n_tasks)
-            
+
+            self.model_type = config.get("model_type")
+            self.model_params = config.get("model_params", {})
+            self.feat_name = config.get("feat_name")
+            self.feat_params = config.get("feat_params", {})
+            self.threshold = config.get("threshold", 0.5)
+            self.param_space = config.get("param_space", {})
+            self.n_tasks = config.get("n_tasks", self.n_tasks)
+
             self.model_dir = os.path.join(self.trainer_dir, f"{self.model_type}_model")
             os.makedirs(self.model_dir, exist_ok=True)
-            
+
             if os.path.abspath(model_path) != os.path.abspath(self.model_dir):
                 for item in os.listdir(model_path):
                     s = os.path.join(model_path, item)
@@ -77,25 +87,29 @@ class HallucinationTrainer:
                         shutil.copytree(s, d, dirs_exist_ok=True)
                     else:
                         shutil.copy2(s, d)
-                        
+
         elif model_type is not None:
             self.model_type = model_type.lower()
             if self.model_type not in MODEL_CONFIGS:
-                raise ValueError(f"Unknown model_type: {self.model_type}. Available: {list(MODEL_CONFIGS.keys())}")
-            
+                raise ValueError(
+                    f"Unknown model_type: {self.model_type}. Available: {list(MODEL_CONFIGS.keys())}"
+                )
+
             config = MODEL_CONFIGS[self.model_type]
-            self.model_params = config['default_params']
-            self.param_space = config['param_space']
-            self.feat_name = config['default_feat']
+            self.model_params = config["default_params"]
+            self.param_space = config["param_space"]
+            self.feat_name = config["default_feat"]
 
             # Adopt model default featurizer parameter mappings if none are supplied externally
             if self.feat_params is None:
-                self.feat_params = config['default_feat_params'].copy()
+                self.feat_params = config["default_feat_params"].copy()
 
             self.model_dir = os.path.join(self.trainer_dir, f"{self.model_type}_model")
             os.makedirs(self.model_dir, exist_ok=True)
         else:
-            raise ValueError("You must provide either a 'model_type' (for a new model) or a 'model_path' (to load an existing one).")
+            raise ValueError(
+                "You must provide either a 'model_type' (for a new model) or a 'model_path' (to load an existing one)."
+            )
 
         # Dynamically build ReactionStepFeaturizer wrapper using the model-specific base configuration mappings
         feat_config = FEATURIZER_MAP[self.feat_name.lower()]
@@ -111,9 +125,9 @@ class HallucinationTrainer:
             Number of prediction tasks.
         """
         params = self.model_params.copy()
-        params['model_dir'] = self.model_dir
-        params['n_tasks'] = n_tasks
-        
+        params["model_dir"] = self.model_dir
+        params["n_tasks"] = n_tasks
+
         self.model = create_model_instance(self.model_type, **params)
 
         if os.path.exists(self.model_dir) and os.listdir(self.model_dir):
@@ -122,12 +136,14 @@ class HallucinationTrainer:
             except Exception:
                 self.model.reload()
 
-    def load_dataset(self,
-                    train_csv: str,
-                    test_csv: str,
-                    product_col: str = "product",
-                    reactants_col: str = "reactants",
-                    label_col: str = "label",) -> Tuple[dc.data.Dataset, dc.data.Dataset]:
+    def load_dataset(
+        self,
+        train_csv: str,
+        test_csv: str,
+        product_col: str = "product",
+        reactants_col: str = "reactants",
+        label_col: str = "label",
+    ) -> Tuple[dc.data.Dataset, dc.data.Dataset]:
         """
         Loads and featurizes train and test datasets.
 
@@ -150,7 +166,9 @@ class HallucinationTrainer:
             Train and test datasets.
         """
         if self.n_tasks != 1:
-            raise ValueError(f"Configured n_tasks ({self.n_tasks}) does not match the number of label columns ({1}).")
+            raise ValueError(
+                f"Configured n_tasks ({self.n_tasks}) does not match the number of label columns ({1})."
+            )
 
         loader = ReactionDataLoader(
             featurizer=self.featurizer,
@@ -161,15 +179,17 @@ class HallucinationTrainer:
 
         print(f"Loading training data from {train_csv}")
         train_dataset = loader.create_dataset(train_csv)
-        
+
         print(f"Loading testing data from {test_csv}")
         test_dataset = loader.create_dataset(test_csv)
 
         return train_dataset, test_dataset
 
-    def optimize_threshold(self,
-                           model: dc.models.Model,
-                           valid_dataset: dc.data.Dataset,) -> float:
+    def optimize_threshold(
+        self,
+        model: dc.models.Model,
+        valid_dataset: dc.data.Dataset,
+    ) -> float:
         """
         Computes the F1 scores across precision-recall thresholds and returns the best threshold.
 
@@ -187,7 +207,7 @@ class HallucinationTrainer:
         """
         y_true = valid_dataset.y.flatten()
         y_pred = model.predict(valid_dataset)
-        
+
         # Handles both (N, 1, 2) and (N, 2) shapes cleanly without corruption
         if len(y_pred.shape) == 3 and y_pred.shape[2] == 2:
             y_pred_proba = y_pred[:, :, 1].flatten()
@@ -195,30 +215,31 @@ class HallucinationTrainer:
             y_pred_proba = y_pred[:, 1].flatten()
         else:
             y_pred_proba = y_pred.flatten()
-            
+
         precisions, recalls, thresholds = precision_recall_curve(y_true, y_pred_proba)
-        
+
         f1_scores = np.divide(
-            2 * (precisions * recalls), 
-            (precisions + recalls), 
-            out=np.zeros_like(precisions), 
-            where=(precisions + recalls) != 0
+            2 * (precisions * recalls),
+            (precisions + recalls),
+            out=np.zeros_like(precisions),
+            where=(precisions + recalls) != 0,
         )
-        
+
         best_idx = np.argmax(f1_scores)
-        
+
         if best_idx == len(thresholds):
             best_threshold = thresholds[-1]
         else:
             best_threshold = thresholds[best_idx]
-            
+
         return best_threshold
 
-    def parameter_tuning(self,
-                        train_dataset: dc.data.Dataset,
-                        n_trials: int = 10,
-                        k_folds: int = 1,
-                        ) -> tuple[dict[str, Any], float]:
+    def parameter_tuning(
+        self,
+        train_dataset: dc.data.Dataset,
+        n_trials: int = 10,
+        k_folds: int = 1,
+    ) -> tuple[dict[str, Any], float]:
         """
         Performs hyperparameter optimization.
 
@@ -242,63 +263,77 @@ class HallucinationTrainer:
             return self.model_params, self.threshold
 
         tune_space = self.param_space.copy()
-        tune_space['n_tasks'] = [self.n_tasks]
+        tune_space["n_tasks"] = [self.n_tasks]
 
         eval_metric = dc.metrics.Metric(dc.metrics.prc_auc_score)
-        lambda_model_builder = lambda **params: create_model_instance(self.model_type, **params)
-        
-        if k_folds <= 1:
-            print(f"Starting single-split random hyperparameter tuning with {n_trials} trials...")
-            splitter = dc.splits.RandomStratifiedSplitter()
-            tune_train, tune_valid = splitter.train_test_split(train_dataset, frac_train=0.8)
 
-            optimizer = dc.hyper.RandomHyperparamOpt(model_builder=lambda_model_builder, max_iter=n_trials)
-            
+        def lambda_model_builder(**params):
+            return create_model_instance(self.model_type, **params)
+
+        if k_folds <= 1:
+            print(
+                f"Starting single-split random hyperparameter tuning with {n_trials} trials..."
+            )
+            splitter = dc.splits.RandomStratifiedSplitter()
+            tune_train, tune_valid = splitter.train_test_split(
+                train_dataset, frac_train=0.8
+            )
+
+            optimizer = dc.hyper.RandomHyperparamOpt(
+                model_builder=lambda_model_builder, max_iter=n_trials
+            )
+
             best_model, best_params, all_scores = optimizer.hyperparam_search(
                 params_dict=tune_space,
                 train_dataset=tune_train,
                 valid_dataset=tune_valid,
                 metric=eval_metric,
-                use_max=True
+                use_max=True,
             )
 
             best_threshold = self.optimize_threshold(best_model, tune_valid)
-            
+
         else:
-            print(f"Starting K-Fold ({k_folds}) random hyperparameter tuning with {n_trials} trials...")
+            print(
+                f"Starting K-Fold ({k_folds}) random hyperparameter tuning with {n_trials} trials..."
+            )
             splitter = dc.splits.RandomStratifiedSplitter()
             folds = list(splitter.k_fold_split(train_dataset, k_folds))
 
-            optimizer = KFoldRandomHyperparamOpt(model_builder=lambda_model_builder, max_iter=n_trials)
-            
-            best_models, best_params, all_scores = optimizer.hyperparam_kfold_search(
-                params_dict=tune_space,
-                folds=folds,
-                metric=eval_metric,
-                use_max=True
+            optimizer = KFoldRandomHyperparamOpt(
+                model_builder=lambda_model_builder, max_iter=n_trials
             )
-            print("Calculating average optimal threshold across folds for best parameters...")
+
+            best_models, best_params, all_scores = optimizer.hyperparam_kfold_search(
+                params_dict=tune_space, folds=folds, metric=eval_metric, use_max=True
+            )
+            print(
+                "Calculating average optimal threshold across folds for best parameters..."
+            )
             fold_thresholds = []
             for fold_model, (_, valid_dataset) in zip(best_models, folds):
                 thresh = self.optimize_threshold(fold_model, valid_dataset)
                 fold_thresholds.append(thresh)
-                
+
             best_threshold = np.mean(fold_thresholds)
 
-        best_score = all_scores.get(dc.hyper.base_classes._convert_hyperparam_dict_to_filename(best_params), 0.0)
-        best_params.pop('n_tasks', None)
-        best_params.pop('model_dir', None)
+        best_score = all_scores.get(
+            dc.hyper.base_classes._convert_hyperparam_dict_to_filename(best_params), 0.0
+        )
+        best_params.pop("n_tasks", None)
+        best_params.pop("model_dir", None)
 
-        print(f"\n--- Tuning Complete ---")
+        print("\n--- Tuning Complete ---")
         print(f"Best Params: {best_params}")
         print(f"Best Threshold: {best_threshold:.4f} (PRC-AUC Score: {best_score:.4f})")
-        
+
         return best_params, best_threshold
 
-    def evaluate(self,
-                dataset: dc.data.Dataset,
-                metrics: List[dc.metrics.Metric] | None = None,
-                ) -> Dict[str, float]:
+    def evaluate(
+        self,
+        dataset: dc.data.Dataset,
+        metrics: List[dc.metrics.Metric] | None = None,
+    ) -> Dict[str, float]:
         """
         Evaluates the model on a given dataset using base metrics and threshold-based metrics.
 
@@ -316,33 +351,37 @@ class HallucinationTrainer:
         """
 
         if self.model is None:
-            raise RuntimeError("Model has not been instantiated. Ensure _build_model is triggered before evaluating.")
-        
+            raise RuntimeError(
+                "Model has not been instantiated. Ensure _build_model is triggered before evaluating."
+            )
+
         if metrics is None:
             metrics = [
                 dc.metrics.Metric(dc.metrics.roc_auc_score, name="ROC_AUC"),
-                dc.metrics.Metric(dc.metrics.prc_auc_score, name="PRC_AUC")
+                dc.metrics.Metric(dc.metrics.prc_auc_score, name="PRC_AUC"),
             ]
-            
+
         print("Evaluating dataset...")
         scores = self.model.evaluate(dataset, metrics)
-        
+
         y_true = dataset.y.flatten()
         y_pred = self.model.predict(dataset)
-        
+
         if len(y_pred.shape) == 3 and y_pred.shape[2] == 2:
             y_pred_proba = y_pred[:, :, 1].flatten()
         elif len(y_pred.shape) == 2 and y_pred.shape[1] == 2:
             y_pred_proba = y_pred[:, 1].flatten()
         else:
             y_pred_proba = y_pred.flatten()
-            
+
         y_pred_bin = (y_pred_proba >= self.threshold).astype(int)
-        
-        scores['threshold_accuracy'] = accuracy_score(y_true, y_pred_bin)
-        scores['threshold_precision'] = precision_score(y_true, y_pred_bin, zero_division=0)
-        scores['threshold_recall'] = recall_score(y_true, y_pred_bin, zero_division=0)
-        
+
+        scores["threshold_accuracy"] = accuracy_score(y_true, y_pred_bin)
+        scores["threshold_precision"] = precision_score(
+            y_true, y_pred_bin, zero_division=0
+        )
+        scores["threshold_recall"] = recall_score(y_true, y_pred_bin, zero_division=0)
+
         print(f"Evaluation Scores: {scores}")
         return scores
 
@@ -351,31 +390,32 @@ class HallucinationTrainer:
         Saves the current trainer configuration to a JSON file in the model directory.
         """
         os.makedirs(self.model_dir, exist_ok=True)
-        config_path = os.path.join(self.model_dir, 'config.json')
-        
+        config_path = os.path.join(self.model_dir, "config.json")
+
         config = {
-            'model_type': self.model_type,
-            'model_params': self.model_params,
-            'feat_name': self.feat_name,
-            'feat_params': self.feat_params,
-            'threshold': float(self.threshold),
-            'param_space': self.param_space,
-            'n_tasks': self.n_tasks
+            "model_type": self.model_type,
+            "model_params": self.model_params,
+            "feat_name": self.feat_name,
+            "feat_params": self.feat_params,
+            "threshold": float(self.threshold),
+            "param_space": self.param_space,
+            "n_tasks": self.n_tasks,
         }
-        
-        with open(config_path, 'w') as f:
+
+        with open(config_path, "w") as f:
             json.dump(config, f, indent=4)
-            
+
         print(f"Trainer configuration successfully saved to {config_path}")
 
-    def train_model(self,
-                    train_dataset: dc.data.Dataset,
-                    test_dataset: dc.data.Dataset,
-                    tune_params: bool = False,
-                    n_trials: int = 10,
-                    k_folds: int = 1,
-                    **train_params: Any,
-                    ) -> tuple[dc.models.Model, dict[str, float]]:
+    def train_model(
+        self,
+        train_dataset: dc.data.Dataset,
+        test_dataset: dc.data.Dataset,
+        tune_params: bool = False,
+        n_trials: int = 10,
+        k_folds: int = 1,
+        **train_params: Any,
+    ) -> tuple[dc.models.Model, dict[str, float]]:
         """
         Trains the final model on the provided dataset. Can optionally tune parameters first.
 
@@ -398,26 +438,28 @@ class HallucinationTrainer:
         -------
         tuple[Model, dict[str, float]]
             Trained model and evaluation scores.
-    
+
         """
         if tune_params:
             print("\n--- Initiating Pre-Training Parameter Tuning ---")
-            best_params, best_threshold = self.parameter_tuning(train_dataset, n_trials=n_trials, k_folds=k_folds)
+            best_params, best_threshold = self.parameter_tuning(
+                train_dataset, n_trials=n_trials, k_folds=k_folds
+            )
             self.model_params = best_params
             self.threshold = best_threshold
 
         print(f"\n--- Building and Training Final {self.model_type.upper()} Model ---")
         self._build_model(self.n_tasks)
-        
+
         self.model.fit(train_dataset, **train_params)
         print("\n--- Final Training Complete. Evaluating on Test Dataset ---")
         test_scores = self.evaluate(test_dataset)
-        
+
         print("\n--- Saving Model and Configuration ---")
         try:
             self.model.save()
         except NotImplementedError:
             raise NotImplementedError("Model save method not implemented.")
-            
+
         self.save_config()
         return self.model, test_scores


### PR DESCRIPTION
## Problem

The **lint**, **type-check**, and **docs build** jobs are currently failing on \`dev\`, so every PR branched off \`dev\` (e.g. #251) inherits red CI even when the PR itself is clean. None of the failures are behavioral — they are lint/typing/docstring issues in the recently-added hallucination/featurizer code.

## Fixes

**lint (ruff)** — 6 errors across 3 files:
- Removed unused imports: \`typing.Optional\` / \`resolve_hallucination\` (autosolve.py), \`typing.Dict\` (hallucination_checker.py), \`GraphData\` (hallucination_trainer.py)
- Rewrote a \`lambda\` assignment as a \`def\` (E731)
- Dropped an f-string without placeholders (F541)

**type-check (ty)** — `reactionstep.py`:
- \`np.ndarray | GraphData\` was evaluated at import time (and confused ty) → added \`from __future__ import annotations\`
- Typed \`FEATURIZER_MAP\` entries via a \`TypedDict\` so \`config["class"]\` resolves as callable
- Added the missing return path (\`_featurize\` could implicitly return \`None\`)
- Explicitly imported the \`deepchem.feat\` submodule

**docs build** — the runtime union above crashed autodoc's import (\`TypeError: unsupported operand type(s) for |\`); the \`__future__\` import fixes it. Also corrected a malformed RST bullet list in the \`ReactionStepFeaturizer\` docstring.

**format-check** — ran \`ruff format\` on the touched files so the changed-file format gate stays green.

