### PR TITLE
Added thinking trace preservation for the agent loop

### DIFF
--- a/deepretro/agents/loop.py
+++ b/deepretro/agents/loop.py
@@ -9,8 +9,8 @@ confidence)`` shape and is *still* run through the deterministic safety filters
 in :meth:`AutoSolver.run_llm`.
 
 The model call is injectable (``llm_runner``) so the loop is unit-tested with no
-network. The default runner calls ``litellm.completion`` with the tool schemas
-and normalizes the returned message to an OpenAI-format assistant dict.
+network. Every returned assistant message crosses a lossless history boundary
+before the loop inspects tool calls or visible content.
 """
 
 from __future__ import annotations
@@ -21,12 +21,13 @@ from typing import Any, cast
 
 import structlog
 
+from deepretro.agents.message_history import append_assistant_message
 from deepretro.agents.tools import build_tool_registry
 from deepretro.utils.llm_helpers import ChatMessage, Pathway
 
 logger = structlog.get_logger(__name__)
 
-ModelCall = Callable[[list[dict[str, Any]]], dict[str, Any]]
+ModelCall = Callable[[list[dict[str, Any]]], Any]
 
 _TOOL_INSTRUCTION = (
     "\n\nYou may call the provided tools to validate SMILES, check stability, "
@@ -46,7 +47,7 @@ def agentic_single_step(
     hallucination_checker: Any | None = None,
     max_iterations: int = 6,
     llm_runner: ModelCall | None = None,
-    enable_thinking: bool = False,
+    enable_thinking: bool = True,
     max_output_tokens: int | None = None,
     event_sink: list[dict[str, Any]] | None = None,
     az_tools: bool = False,
@@ -69,12 +70,15 @@ def agentic_single_step(
     max_iterations : int, optional
         Maximum model turns before giving up.
     llm_runner : callable, optional
-        Injectable model call ``(messages) -> assistant_message_dict``. When
-        ``None``, ``litellm.completion`` is used.
+        Injectable model call ``(messages) -> assistant_message``. The result
+        may be a serialized mapping or an object exposing ``model_dump()``.
+        When ``None``, ``litellm.completion`` is used.
     enable_thinking : bool, optional
-        Reasoning controls. Defaults to ``False``: multi-turn tool use with
-        extended thinking is rejected by Anthropic unless the signed thinking
-        block is preserved.
+        Whether provider-supported reasoning controls should be enabled.
+        Defaults to ``True``. Provider-returned reasoning artifacts are treated
+        as opaque protocol data and retained in memory only for this agent run
+        so signed multi-turn tool conversations can be replayed losslessly.
+        Pass ``False`` to disable provider reasoning explicitly.
     max_output_tokens : int, optional
         Output-token override for the model call.
     event_sink : list of dict or None, optional
@@ -113,8 +117,7 @@ def agentic_single_step(
     )
 
     for _iteration in range(max_iterations):
-        assistant = call_model(messages)
-        messages.append(assistant)
+        assistant = append_assistant_message(messages, call_model(messages))
 
         tool_calls = assistant.get("tool_calls")
         if not tool_calls:
@@ -265,7 +268,7 @@ def _make_default_model_call(
 ) -> ModelCall:
     """Build the default ``litellm.completion``-backed model call."""
 
-    def _call(messages: list[dict[str, Any]]) -> dict[str, Any]:
+    def _call(messages: list[dict[str, Any]]) -> Any:
         from litellm import completion
 
         from deepretro.utils.llm_helpers import build_completion_params
@@ -282,7 +285,6 @@ def _make_default_model_call(
         )
         params["tools"] = tools
         response = completion(**params)
-        message = response.choices[0].message
-        return message.model_dump()
+        return response.choices[0].message
 
     return _call

--- a/deepretro/agents/loop.py
+++ b/deepretro/agents/loop.py
@@ -181,7 +181,16 @@ def agentic_orchestrator(
 
 
 def _build_initial_messages(molecule: str, model: str) -> list[dict[str, Any]]:
-    """Build the [system, user] messages with tool-usage guidance appended."""
+    """Build the system and user messages with tool guidance appended.
+
+    Examples
+    --------
+    >>> messages = _build_initial_messages("CCO", "openai/gpt-4o-mini")
+    >>> [message["role"] for message in messages]
+    ['system', 'user']
+    >>> "You may call" in messages[0]["content"]
+    True
+    """
     from deepretro.utils.llm import build_messages
 
     messages = [dict(message) for message in build_messages(molecule, model)]
@@ -232,7 +241,15 @@ def _classify_agent_event(molecule: str, content: str) -> dict[str, Any]:
 
 
 def _parse_arguments(arguments: Any) -> dict[str, Any]:
-    """Parse tool-call arguments (a JSON string or already a dict)."""
+    """Parse tool-call arguments from a JSON string or existing dictionary.
+
+    Examples
+    --------
+    >>> _parse_arguments('{"smiles": "CCO"}')
+    {'smiles': 'CCO'}
+    >>> _parse_arguments("not JSON")
+    {}
+    """
     if isinstance(arguments, dict):
         return arguments
     if not arguments:
@@ -248,7 +265,17 @@ def _parse_final_answer(
     content: str,
     model: str,
 ) -> tuple[list[Pathway], list[str], list[float]]:
-    """Parse a final assistant message into pathways/explanations/confidence."""
+    """Parse a final assistant message into pipeline result lists.
+
+    Examples
+    --------
+    >>> content = (
+    ...     '<json>{"data": [["CCO"]], "explanation": ["reduce"], '
+    ...     '"confidence_scores": [0.8]}</json>'
+    ... )
+    >>> _parse_final_answer(content, "openai/gpt-4o-mini")
+    ([['CCO']], ['reduce'], [0.8])
+    """
     from deepretro.utils.llm import parse_response, validate_split_json
 
     status, _thinking, json_content = parse_response(content, model)
@@ -266,9 +293,30 @@ def _make_default_model_call(
     enable_thinking: bool,
     max_output_tokens: int | None,
 ) -> ModelCall:
-    """Build the default ``litellm.completion``-backed model call."""
+    """Build the default ``litellm.completion``-backed model call.
 
-    def _call(messages: list[dict[str, Any]]) -> Any:
+    Examples
+    --------
+    >>> call_model = _make_default_model_call(
+    ...     "openai/gpt-4o-mini", [], True, 1024
+    ... )
+    >>> callable(call_model)
+    True
+    """
+
+    def _call(messages: list[dict[str, Any]]) -> object:
+        """Send one conversation turn to LiteLLM and return its raw message.
+
+        Examples
+        --------
+        The closure is obtained through ``_make_default_model_call``:
+
+        >>> call_model = _make_default_model_call(
+        ...     "openai/gpt-4o-mini", [], True, 1024
+        ... )
+        >>> callable(call_model)
+        True
+        """
         from litellm import completion
 
         from deepretro.utils.llm_helpers import build_completion_params

--- a/deepretro/agents/message_history.py
+++ b/deepretro/agents/message_history.py
@@ -1,0 +1,91 @@
+"""Lossless in-memory preservation for provider assistant messages.
+
+Assistant messages can contain signed, encrypted, or provider-specific
+reasoning fields needed by a later tool-calling turn.  This module treats the
+complete serialized message as opaque protocol data: it validates only the
+outer role and returns an isolated snapshot without filtering nested fields.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+
+class MessagePreservationError(RuntimeError):
+    """Raised when an assistant message cannot be preserved losslessly."""
+
+
+def _serialize_message(message: Any) -> Mapping[str, Any]:
+    """Return a complete mapping representation without inspecting its data."""
+    if isinstance(message, Mapping):
+        return message
+
+    try:
+        model_dump = getattr(message, "model_dump", None)
+    except Exception:
+        raise MessagePreservationError(
+            "Assistant message serialization failed"
+        ) from None
+    if not callable(model_dump):
+        raise MessagePreservationError("Unsupported assistant message object")
+    try:
+        serialized = model_dump()
+    except Exception:
+        raise MessagePreservationError(
+            "Assistant message serialization failed"
+        ) from None
+    if not isinstance(serialized, Mapping):
+        raise MessagePreservationError(
+            "Assistant message serialization did not return a mapping"
+        )
+    return serialized
+
+
+def snapshot_assistant_message(message: Any) -> dict[str, Any]:
+    """Return an isolated, complete Python snapshot of an assistant message.
+
+    Parameters
+    ----------
+    message : mapping or Pydantic-compatible object
+        Serialized assistant mapping or an object exposing ``model_dump()``.
+
+    Returns
+    -------
+    dict[str, Any]
+        A recursively independent snapshot containing every serialized field.
+
+    Raises
+    ------
+    MessagePreservationError
+        If the object cannot be serialized, is not an assistant turn, or
+        cannot be copied. Error text never includes response data.
+    """
+    serialized = _serialize_message(message)
+    try:
+        is_assistant = serialized.get("role") == "assistant"
+    except Exception:
+        raise MessagePreservationError(
+            "Assistant message preservation failed"
+        ) from None
+    if not is_assistant:
+        raise MessagePreservationError("Expected an assistant message")
+
+    try:
+        snapshot = deepcopy(dict(serialized))
+    except Exception:
+        raise MessagePreservationError(
+            "Assistant message preservation failed"
+        ) from None
+    return snapshot
+
+
+def append_assistant_message(
+    history: list[dict[str, Any]],
+    message: Any,
+) -> dict[str, Any]:
+    """Snapshot one assistant message, append it, and return the snapshot."""
+    snapshot = snapshot_assistant_message(message)
+    history.append(snapshot)
+    return snapshot

--- a/deepretro/agents/message_history.py
+++ b/deepretro/agents/message_history.py
@@ -18,7 +18,13 @@ class MessagePreservationError(RuntimeError):
 
 
 def _serialize_message(message: Any) -> Mapping[str, Any]:
-    """Return a complete mapping representation without inspecting its data."""
+    """Return a complete mapping representation without inspecting its data.
+
+    Examples
+    --------
+    >>> _serialize_message({"role": "assistant", "content": "done"})["role"]
+    'assistant'
+    """
     if isinstance(message, Mapping):
         return message
 
@@ -61,6 +67,14 @@ def snapshot_assistant_message(message: Any) -> dict[str, Any]:
     MessagePreservationError
         If the object cannot be serialized, is not an assistant turn, or
         cannot be copied. Error text never includes response data.
+
+    Examples
+    --------
+    >>> original = {"role": "assistant", "metadata": {"signature": "abc"}}
+    >>> snapshot = snapshot_assistant_message(original)
+    >>> original["metadata"]["signature"] = "changed"
+    >>> snapshot["metadata"]["signature"]
+    'abc'
     """
     serialized = _serialize_message(message)
     try:
@@ -85,7 +99,17 @@ def append_assistant_message(
     history: list[dict[str, Any]],
     message: Any,
 ) -> dict[str, Any]:
-    """Snapshot one assistant message, append it, and return the snapshot."""
+    """Snapshot one assistant message, append it, and return the snapshot.
+
+    Examples
+    --------
+    >>> history = []
+    >>> snapshot = append_assistant_message(
+    ...     history, {"role": "assistant", "content": "done"}
+    ... )
+    >>> history == [snapshot]
+    True
+    """
     snapshot = snapshot_assistant_message(message)
     history.append(snapshot)
     return snapshot

--- a/deepretro/tests/test_agents_loop.py
+++ b/deepretro/tests/test_agents_loop.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+import deepretro.agents.loop as agent_loop
 from deepretro.agents.loop import agentic_orchestrator, agentic_single_step
 
 MODEL = "openai/gpt-4o-mini"
@@ -55,6 +56,17 @@ class ScriptedModel:
         return self.turns[len(self.seen) - 1]
 
 
+class ProviderMessage:
+    """Provider-message stand-in exposing a Pydantic-style serializer."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def model_dump(self) -> dict[str, Any]:
+        """Return the provider payload."""
+        return self.payload
+
+
 def test_returns_parsed_pathways_from_final_answer() -> None:
     """A final answer is parsed into the pipeline's (pathways, expl, conf) shape."""
     model = ScriptedModel([final_turn()])
@@ -75,6 +87,51 @@ def test_executes_tool_then_returns_final_answer() -> None:
     assert pathways == [["CCO"]]
     second_call_messages = model.seen[1]
     assert any(message.get("role") == "tool" for message in second_call_messages)
+
+
+def test_replays_provider_message_with_reasoning_fields() -> None:
+    """A serialized provider turn is replayed with opaque reasoning intact."""
+    first_payload = tool_turn()
+    first_payload["reasoning_content"] = {"signature": "signed-token"}
+    seen_second_turn: list[dict[str, Any]] = []
+    calls = 0
+
+    def provider_model(messages: list[dict[str, Any]]) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return ProviderMessage(first_payload)
+        first_payload["reasoning_content"]["signature"] = "changed"
+        seen_second_turn.extend(messages)
+        return ProviderMessage(final_turn())
+
+    result = agentic_single_step("CC=O", MODEL, llm_runner=provider_model)
+
+    assistant_turn = next(
+        message for message in seen_second_turn if message["role"] == "assistant"
+    )
+    assert assistant_turn["reasoning_content"] == {"signature": "signed-token"}
+    assert result == ([["CCO"]], ["reduce"], [0.8])
+
+
+def test_thinking_is_enabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default model-call factory receives thinking enabled."""
+    captured: dict[str, Any] = {}
+
+    def fake_model_call_factory(
+        model: str,
+        tools: list[dict[str, Any]],
+        enable_thinking: bool,
+        max_output_tokens: int | None,
+    ) -> Any:
+        captured["enable_thinking"] = enable_thinking
+        return lambda messages: final_turn()
+
+    monkeypatch.setattr(agent_loop, "_make_default_model_call", fake_model_call_factory)
+
+    agentic_single_step("CC=O", MODEL)
+
+    assert captured["enable_thinking"] is True
 
 
 def test_tool_result_references_call_id() -> None:

--- a/deepretro/tests/test_message_history.py
+++ b/deepretro/tests/test_message_history.py
@@ -1,0 +1,74 @@
+"""Tests for lossless assistant-message history preservation."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from typing import Any
+
+import pytest
+
+from deepretro.agents import loop, message_history
+from deepretro.agents.message_history import (
+    MessagePreservationError,
+    append_assistant_message,
+    snapshot_assistant_message,
+)
+
+
+class ProviderMessage:
+    """Small provider-message stand-in exposing ``model_dump``."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def model_dump(self) -> dict[str, Any]:
+        """Return the provider payload."""
+        return self.payload
+
+
+def test_snapshot_preserves_provider_fields_and_is_independent() -> None:
+    """Provider-specific nested fields survive in an independent snapshot."""
+    payload = {
+        "role": "assistant",
+        "content": None,
+        "reasoning_content": {"signature": "signed-token"},
+    }
+
+    snapshot = snapshot_assistant_message(ProviderMessage(payload))
+    payload["reasoning_content"]["signature"] = "changed"
+
+    assert snapshot["reasoning_content"] == {"signature": "signed-token"}
+
+
+def test_append_assistant_message_adds_and_returns_snapshot() -> None:
+    """Appending stores the exact snapshot returned to the caller."""
+    history: list[dict[str, Any]] = []
+
+    snapshot = append_assistant_message(
+        history,
+        {"role": "assistant", "content": "done", "provider_field": 7},
+    )
+
+    assert history == [snapshot]
+    assert snapshot["provider_field"] == 7
+
+
+def test_snapshot_rejects_non_assistant_message() -> None:
+    """Only assistant turns may cross the preservation boundary."""
+    with pytest.raises(MessagePreservationError, match="Expected an assistant"):
+        snapshot_assistant_message({"role": "user", "content": "hello"})
+
+
+@pytest.mark.parametrize("module", [message_history, loop])
+def test_every_agent_function_docstring_has_an_example(module: Any) -> None:
+    """Every function in the PR modules includes a concrete usage example."""
+    tree = ast.parse(inspect.getsource(module))
+    missing = [
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and "Examples\n" not in (ast.get_docstring(node) or "")
+    ]
+
+    assert missing == []


### PR DESCRIPTION
Preserve provider-returned assistant messages across tool-calling turns so multi-turn extended-thinking conversations can be replayed without loss of reasoning context, which Anthropic requires.

- message_history.py: snapshots each assistant message
- loop.py: route every assistant message through the snapshot boundary; default enable_thinking to True

## Description

Fix #(issue)

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings