### PR TITLE
Added ChemCensor evaluation subpackage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,13 @@ coverage/
 docs/build/
 docs/_build/
 *.egg-info/
+
+# Local ChemCensor evaluation databases, caches, and generated artifacts.
+# Keep these outside Git even when their paths are used by the evaluation CLI.
+artifacts/chemcensor/
+benchmark_reports/
+chem-censor-cache/
+*.chemcensor.sqlite
+*.chemcensor.sqlite-shm
+*.chemcensor.sqlite-wal
+tmp/

--- a/deepretro/evaluation/__init__.py
+++ b/deepretro/evaluation/__init__.py
@@ -1,0 +1,41 @@
+"""Offline plausibility and diversity evaluation for DeepRetro predictions.
+
+This package deliberately does not participate in the production ``src``
+retrosynthesis runtime.  It supplies reproducible, research-facing evaluation
+utilities for ranked single-step precursor predictions.
+"""
+
+from deepretro.evaluation.canonical import canonicalize_prediction
+from deepretro.evaluation.cache import ScoreCache
+from deepretro.evaluation.aggregate import aggregate_benchmark, evaluate_target
+from deepretro.evaluation.io import load_predictions, load_scores, load_targets, write_scores
+from deepretro.evaluation.runner import score_predictions
+from deepretro.evaluation.report import write_benchmark_report, write_score_provenance
+from deepretro.evaluation.chemcensor import OfficialChemCensorScorer
+from deepretro.evaluation.types import (
+    CanonicalPrediction,
+    ChemCensorProvenance,
+    ChemCensorScore,
+    EvaluationTarget,
+    SingleStepPrediction,
+)
+
+__all__ = [
+    "CanonicalPrediction",
+    "ChemCensorProvenance",
+    "ChemCensorScore",
+    "EvaluationTarget",
+    "OfficialChemCensorScorer",
+    "ScoreCache",
+    "aggregate_benchmark",
+    "SingleStepPrediction",
+    "canonicalize_prediction",
+    "evaluate_target",
+    "load_predictions",
+    "load_scores",
+    "load_targets",
+    "score_predictions",
+    "write_benchmark_report",
+    "write_score_provenance",
+    "write_scores",
+]

--- a/deepretro/evaluation/__main__.py
+++ b/deepretro/evaluation/__main__.py
@@ -1,0 +1,9 @@
+"""Module entry point for ``python -m deepretro.evaluation``."""
+
+from __future__ import annotations
+
+from deepretro.evaluation.cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/deepretro/evaluation/aggregate.py
+++ b/deepretro/evaluation/aggregate.py
@@ -1,0 +1,339 @@
+"""Per-target and benchmark ChemCensor plausibility/diversity aggregates."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+from deepretro.evaluation.canonical import canonicalize_prediction, canonicalize_smiles
+from deepretro.evaluation.types import (
+    ChemCensorScore,
+    EvaluationTarget,
+    SingleStepPrediction,
+)
+
+ScoreVariant = Literal["with_functional_groups", "without_functional_groups"]
+
+
+@dataclass(frozen=True)
+class TargetEvaluation:
+    """All reportable metrics for one benchmark target."""
+
+    target_id: str
+    k: int
+    pt_max_cc: float
+    pt_top_k_cc: float
+    top_k_values: tuple[float, ...]
+    exact_match_at_k: bool | None
+    unique_prediction_count: int
+    duplicate_prediction_count: int
+    invalid_prediction_count: int
+    missing_score_count: int
+    processing_failed_count: int
+    no_precedent_count: int
+    scored_prediction_count: int
+
+
+@dataclass(frozen=True)
+class BenchmarkEvaluation:
+    """Mean target-level metrics with denominator and coverage diagnostics."""
+
+    target_evaluations: tuple[TargetEvaluation, ...]
+    target_count: int
+    prediction_coverage: float
+    average_pt_max_cc: float
+    average_pt_top_k_cc: float
+    reference_target_count: int
+    average_exact_match_at_k: float | None
+
+
+def evaluate_target(
+    target: EvaluationTarget,
+    predictions: Sequence[SingleStepPrediction],
+    scores: Sequence[ChemCensorScore],
+    *,
+    k: int,
+    score_variant: ScoreVariant = "with_functional_groups",
+) -> TargetEvaluation:
+    """Compute PT-Max and zero-padded PT-Top-K for one explicit target.
+
+    The maximum examines every unique valid prediction supplied for the target.
+    PT-Top-K instead follows ranked output slots: invalid output consumes a zero
+    slot, while a canonical duplicate consumes no slot and cannot manufacture
+    diversity.  Missing/failed external scores are zero in aggregate values but
+    have separate diagnostic counts.
+    """
+    _validate_metric_arguments(k, score_variant)
+    target_product = canonicalize_smiles(target.product_smiles)
+    if target_product is None:
+        raise ValueError(f"target {target.target_id!r} has invalid product SMILES")
+
+    _validate_prediction_records(target, predictions)
+    score_by_id = _index_scores(scores, predictions)
+    reference_reaction = _canonical_reference_reaction(target)
+
+    unique_reactions: set[str] = set()
+    top_k_values: list[float] = []
+    top_k_reactions: list[str | None] = []
+    pt_max_cc = 0.0
+    duplicate_prediction_count = 0
+    invalid_prediction_count = 0
+    missing_score_count = 0
+    processing_failed_count = 0
+    no_precedent_count = 0
+    scored_prediction_count = 0
+
+    ranked_predictions = sorted(enumerate(predictions), key=lambda item: (item[1].rank, item[0]))
+    for _input_index, prediction in ranked_predictions:
+        canonical_prediction = canonicalize_prediction(prediction)
+        score = score_by_id.get(prediction.prediction_id)
+        if not canonical_prediction.is_valid:
+            invalid_prediction_count += 1
+            _validate_invalid_score(score, prediction.prediction_id)
+            if len(top_k_values) < k:
+                top_k_values.append(0.0)
+                top_k_reactions.append(None)
+            continue
+
+        assert canonical_prediction.canonical_product_smiles is not None
+        if canonical_prediction.canonical_product_smiles != target_product:
+            raise ValueError(
+                f"prediction {prediction.prediction_id!r} product does not match "
+                f"target {target.target_id!r}"
+            )
+        assert canonical_prediction.canonical_reaction_smiles is not None
+        _validate_valid_score(score, canonical_prediction.canonical_reaction_smiles)
+        reaction_smiles = canonical_prediction.canonical_reaction_smiles
+        if reaction_smiles in unique_reactions:
+            duplicate_prediction_count += 1
+            continue
+        unique_reactions.add(reaction_smiles)
+
+        value, score_state = _selected_score_value(score, score_variant)
+        if score_state == "missing":
+            missing_score_count += 1
+        elif score_state == "processing_failed":
+            processing_failed_count += 1
+        elif score_state == "no_precedent":
+            no_precedent_count += 1
+        else:
+            scored_prediction_count += 1
+        pt_max_cc = max(pt_max_cc, value)
+        if len(top_k_values) < k:
+            top_k_values.append(value)
+            top_k_reactions.append(reaction_smiles)
+
+    padded_values = tuple(top_k_values + [0.0] * (k - len(top_k_values)))
+    exact_match_at_k = (
+        None
+        if reference_reaction is None
+        else reference_reaction in top_k_reactions
+    )
+    return TargetEvaluation(
+        target_id=target.target_id,
+        k=k,
+        pt_max_cc=pt_max_cc,
+        pt_top_k_cc=sum(padded_values) / k,
+        top_k_values=padded_values,
+        exact_match_at_k=exact_match_at_k,
+        unique_prediction_count=len(unique_reactions),
+        duplicate_prediction_count=duplicate_prediction_count,
+        invalid_prediction_count=invalid_prediction_count,
+        missing_score_count=missing_score_count,
+        processing_failed_count=processing_failed_count,
+        no_precedent_count=no_precedent_count,
+        scored_prediction_count=scored_prediction_count,
+    )
+
+
+def aggregate_benchmark(
+    targets: Sequence[EvaluationTarget],
+    predictions: Sequence[SingleStepPrediction],
+    scores: Sequence[ChemCensorScore],
+    *,
+    k: int,
+    score_variant: ScoreVariant = "with_functional_groups",
+) -> BenchmarkEvaluation:
+    """Average target-level metrics over the full explicit target denominator."""
+    _validate_metric_arguments(k, score_variant)
+    targets_by_id: dict[str, EvaluationTarget] = {}
+    for target in targets:
+        if target.target_id in targets_by_id:
+            raise ValueError(f"duplicate target_id: {target.target_id!r}")
+        targets_by_id[target.target_id] = target
+    if not targets_by_id:
+        raise ValueError("targets must contain at least one target")
+
+    predictions_by_target: dict[str, list[SingleStepPrediction]] = defaultdict(list)
+    prediction_ids: set[str] = set()
+    for prediction in predictions:
+        if prediction.prediction_id in prediction_ids:
+            raise ValueError(f"duplicate prediction_id: {prediction.prediction_id!r}")
+        prediction_ids.add(prediction.prediction_id)
+        if prediction.target_id not in targets_by_id:
+            raise ValueError(
+                f"prediction {prediction.prediction_id!r} references unknown target "
+                f"{prediction.target_id!r}"
+            )
+        predictions_by_target[prediction.target_id].append(prediction)
+
+    score_by_id: dict[str, ChemCensorScore] = {}
+    for score in scores:
+        if score.prediction_id not in prediction_ids:
+            raise ValueError(
+                f"score references unknown prediction_id: {score.prediction_id!r}"
+            )
+        if score.prediction_id in score_by_id:
+            raise ValueError(f"duplicate score prediction_id: {score.prediction_id!r}")
+        score_by_id[score.prediction_id] = score
+
+    per_target = tuple(
+        evaluate_target(
+            target,
+            predictions_by_target.get(target.target_id, []),
+            [
+                score_by_id[prediction.prediction_id]
+                for prediction in predictions_by_target.get(target.target_id, [])
+                if prediction.prediction_id in score_by_id
+            ],
+            k=k,
+            score_variant=score_variant,
+        )
+        for target in targets
+    )
+    exact_matches = [
+        result.exact_match_at_k
+        for result in per_target
+        if result.exact_match_at_k is not None
+    ]
+    target_count = len(per_target)
+    return BenchmarkEvaluation(
+        target_evaluations=per_target,
+        target_count=target_count,
+        prediction_coverage=(
+            sum(bool(predictions_by_target[target.target_id]) for target in targets)
+            / target_count
+        ),
+        average_pt_max_cc=sum(result.pt_max_cc for result in per_target) / target_count,
+        average_pt_top_k_cc=(
+            sum(result.pt_top_k_cc for result in per_target) / target_count
+        ),
+        reference_target_count=len(exact_matches),
+        average_exact_match_at_k=(
+            None
+            if not exact_matches
+            else sum(bool(value) for value in exact_matches) / len(exact_matches)
+        ),
+    )
+
+
+def _validate_metric_arguments(k: int, score_variant: str) -> None:
+    """Keep aggregate denominator and score selection unambiguous."""
+    if isinstance(k, bool) or not isinstance(k, int) or k < 1:
+        raise ValueError("k must be a positive integer")
+    if score_variant not in {"with_functional_groups", "without_functional_groups"}:
+        raise ValueError(
+            "score_variant must be 'with_functional_groups' or "
+            "'without_functional_groups'"
+        )
+
+
+def _validate_prediction_records(
+    target: EvaluationTarget,
+    predictions: Sequence[SingleStepPrediction],
+) -> None:
+    """Reject ambiguous rank/ID inputs before scoring a target."""
+    prediction_ids: set[str] = set()
+    ranks: set[int] = set()
+    for prediction in predictions:
+        if prediction.target_id != target.target_id:
+            raise ValueError(
+                f"prediction {prediction.prediction_id!r} belongs to "
+                f"{prediction.target_id!r}, not {target.target_id!r}"
+            )
+        if prediction.prediction_id in prediction_ids:
+            raise ValueError(f"duplicate prediction_id: {prediction.prediction_id!r}")
+        if prediction.rank in ranks:
+            raise ValueError(
+                f"target {target.target_id!r} has duplicate rank {prediction.rank}"
+            )
+        prediction_ids.add(prediction.prediction_id)
+        ranks.add(prediction.rank)
+
+
+def _index_scores(
+    scores: Sequence[ChemCensorScore],
+    predictions: Sequence[SingleStepPrediction],
+) -> dict[str, ChemCensorScore]:
+    """Index scores while rejecting stale and duplicate artifact rows."""
+    prediction_ids = {prediction.prediction_id for prediction in predictions}
+    indexed: dict[str, ChemCensorScore] = {}
+    for score in scores:
+        if score.prediction_id not in prediction_ids:
+            raise ValueError(
+                f"score references unknown prediction_id: {score.prediction_id!r}"
+            )
+        if score.prediction_id in indexed:
+            raise ValueError(f"duplicate score prediction_id: {score.prediction_id!r}")
+        indexed[score.prediction_id] = score
+    return indexed
+
+
+def _validate_invalid_score(score: ChemCensorScore | None, prediction_id: str) -> None:
+    """Ensure an artifact cannot claim a score for an invalid current reaction."""
+    if score is not None and score.status != "invalid":
+        raise ValueError(
+            f"invalid prediction {prediction_id!r} has a non-invalid score artifact"
+        )
+
+
+def _validate_valid_score(
+    score: ChemCensorScore | None,
+    canonical_reaction_smiles: str,
+) -> None:
+    """Reject score records produced for a different canonical prediction."""
+    if score is None:
+        return
+    if score.canonical_reaction_smiles != canonical_reaction_smiles:
+        raise ValueError(
+            "score artifact reaction does not match current canonical prediction: "
+            f"{score.prediction_id!r}"
+        )
+
+
+def _selected_score_value(
+    score: ChemCensorScore | None,
+    score_variant: ScoreVariant,
+) -> tuple[float, str]:
+    """Normalize unavailable/failed results to zero without concealing status."""
+    if score is None:
+        return 0.0, "missing"
+    if score.status == "processing_failed":
+        return 0.0, "processing_failed"
+    if score.status == "invalid":
+        return 0.0, "missing"
+    if score.status == "no_precedent":
+        return 0.0, "no_precedent"
+    value = getattr(score, score_variant)
+    assert value is not None
+    return float(value), "scored"
+
+
+def _canonical_reference_reaction(target: EvaluationTarget) -> str | None:
+    """Canonicalize an optional literature precursor set using the same rules."""
+    if target.reference_precursor_smiles is None:
+        return None
+    reference = SingleStepPrediction(
+        prediction_id=f"{target.target_id}:reference",
+        target_id=target.target_id,
+        rank=1,
+        product_smiles=target.product_smiles,
+        precursor_smiles=target.reference_precursor_smiles,
+    )
+    canonical_reference = canonicalize_prediction(reference)
+    if not canonical_reference.is_valid:
+        raise ValueError(
+            f"target {target.target_id!r} has invalid reference precursor SMILES"
+        )
+    return canonical_reference.canonical_reaction_smiles

--- a/deepretro/evaluation/cache.py
+++ b/deepretro/evaluation/cache.py
@@ -1,0 +1,148 @@
+"""Small local SQLite cache for reproducible official score reuse."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from deepretro.evaluation.types import ChemCensorProvenance, ChemCensorScore
+
+
+class ScoreCache:
+    """Persist successful official scores under their full scorer provenance.
+
+    Processing failures are intentionally not cached: an unavailable mapper or
+    temporary SQLite problem must not turn into a permanent zero-coverage
+    artifact in future evaluation runs.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        """Create the local cache database and its provenance-aware table."""
+        self.path = Path(path).expanduser().resolve()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS chemcensor_scores (
+                    canonical_reaction_smiles TEXT NOT NULL,
+                    scorer_name TEXT NOT NULL,
+                    package_version TEXT NOT NULL,
+                    database_version TEXT NOT NULL,
+                    database_sha256 TEXT NOT NULL,
+                    max_center_type INTEGER NOT NULL,
+                    find_exact_match INTEGER NOT NULL,
+                    with_functional_groups REAL NOT NULL,
+                    without_functional_groups REAL NOT NULL,
+                    status TEXT NOT NULL,
+                    PRIMARY KEY (
+                        canonical_reaction_smiles,
+                        scorer_name,
+                        package_version,
+                        database_version,
+                        database_sha256,
+                        max_center_type,
+                        find_exact_match
+                    )
+                )
+                """
+            )
+
+    def get(
+        self,
+        canonical_reaction_smiles: str,
+        provenance: ChemCensorProvenance,
+        *,
+        prediction_id: str,
+    ) -> ChemCensorScore | None:
+        """Return a matching cached score rebound to the current prediction ID."""
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT with_functional_groups, without_functional_groups, status
+                FROM chemcensor_scores
+                WHERE canonical_reaction_smiles = ?
+                  AND scorer_name = ?
+                  AND package_version = ?
+                  AND database_version = ?
+                  AND database_sha256 = ?
+                  AND max_center_type = ?
+                  AND find_exact_match = ?
+                """,
+                _cache_key(canonical_reaction_smiles, provenance),
+            ).fetchone()
+        if row is None:
+            return None
+        return ChemCensorScore(
+            prediction_id=prediction_id,
+            canonical_reaction_smiles=canonical_reaction_smiles,
+            with_functional_groups=float(row[0]),
+            without_functional_groups=float(row[1]),
+            status=str(row[2]),
+            provenance=provenance,
+        )
+
+    def put(self, score: ChemCensorScore) -> None:
+        """Store only stable, successful/no-precedent official results."""
+        if score.status not in {"scored", "no_precedent"}:
+            return
+        if score.provenance is None or score.canonical_reaction_smiles is None:
+            raise ValueError("cacheable ChemCensor scores require provenance and reaction")
+        assert score.with_functional_groups is not None
+        assert score.without_functional_groups is not None
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO chemcensor_scores (
+                    canonical_reaction_smiles,
+                    scorer_name,
+                    package_version,
+                    database_version,
+                    database_sha256,
+                    max_center_type,
+                    find_exact_match,
+                    with_functional_groups,
+                    without_functional_groups,
+                    status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(
+                    canonical_reaction_smiles,
+                    scorer_name,
+                    package_version,
+                    database_version,
+                    database_sha256,
+                    max_center_type,
+                    find_exact_match
+                ) DO UPDATE SET
+                    with_functional_groups = excluded.with_functional_groups,
+                    without_functional_groups = excluded.without_functional_groups,
+                    status = excluded.status
+                """,
+                (
+                    *_cache_key(score.canonical_reaction_smiles, score.provenance),
+                    score.with_functional_groups,
+                    score.without_functional_groups,
+                    score.status,
+                ),
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a short-lived transaction-safe SQLite connection."""
+        connection = sqlite3.connect(self.path, timeout=30)
+        connection.execute("PRAGMA journal_mode=WAL")
+        return connection
+
+
+def _cache_key(
+    canonical_reaction_smiles: str,
+    provenance: ChemCensorProvenance,
+) -> tuple[str, str, str, str, str, int, int]:
+    """Return the exact tuple used by both cache reads and writes."""
+    return (
+        canonical_reaction_smiles,
+        provenance.scorer_name,
+        provenance.package_version,
+        provenance.database_version,
+        provenance.database_sha256,
+        provenance.max_center_type,
+        int(provenance.find_exact_match),
+    )

--- a/deepretro/evaluation/canonical.py
+++ b/deepretro/evaluation/canonical.py
@@ -1,0 +1,68 @@
+"""SMILES canonicalization and forward-reaction construction."""
+
+from __future__ import annotations
+
+from deepretro.evaluation.types import CanonicalPrediction, SingleStepPrediction
+from deepretro.utils.utils_molecule import canonicalize, is_valid_smiles
+
+
+def canonicalize_prediction(prediction: SingleStepPrediction) -> CanonicalPrediction:
+    """Canonicalize one precursor set and construct ``precursors>>product``.
+
+    The operation preserves duplicate precursor components because their
+    multiplicity may carry experimental meaning.  It sorts only their
+    canonicalized order so equivalent unordered precursor sets share a stable
+    diversity key.
+    """
+    canonical_product = canonicalize_smiles(prediction.product_smiles)
+    if canonical_product is None:
+        return _invalid_prediction(
+            prediction,
+            f"invalid product SMILES: {prediction.product_smiles!r}",
+        )
+
+    canonical_precursors: list[str] = []
+    for index, precursor in enumerate(prediction.precursor_smiles):
+        canonical_precursor = canonicalize_smiles(precursor)
+        if canonical_precursor is None:
+            return _invalid_prediction(
+                prediction,
+                f"invalid precursor SMILES at index {index}: {precursor!r}",
+            )
+        canonical_precursors.append(canonical_precursor)
+
+    sorted_precursors = tuple(sorted(canonical_precursors))
+    reaction_smiles = f"{'.'.join(sorted_precursors)}>>{canonical_product}"
+    return CanonicalPrediction(
+        prediction=prediction,
+        canonical_product_smiles=canonical_product,
+        canonical_precursor_smiles=sorted_precursors,
+        canonical_reaction_smiles=reaction_smiles,
+    )
+
+
+def canonicalize_smiles(smiles: str) -> str | None:
+    """Return an isomeric canonical SMILES or ``None`` when invalid.
+
+    Delegates to the package-standard helpers in
+    :mod:`deepretro.utils.utils_molecule`.  ``canonicalize`` returns the input
+    unchanged on a parse failure, so validity is checked first to preserve this
+    function's ``None`` contract.
+    """
+    if not is_valid_smiles(smiles):
+        return None
+    return canonicalize(smiles)
+
+
+def _invalid_prediction(
+    prediction: SingleStepPrediction,
+    error: str,
+) -> CanonicalPrediction:
+    """Build the common audit representation for invalid model output."""
+    return CanonicalPrediction(
+        prediction=prediction,
+        canonical_product_smiles=None,
+        canonical_precursor_smiles=None,
+        canonical_reaction_smiles=None,
+        error=error,
+    )

--- a/deepretro/evaluation/chemcensor.py
+++ b/deepretro/evaluation/chemcensor.py
@@ -1,0 +1,230 @@
+"""Optional adapter for the official local ChemCensor implementation.
+
+DeepRetro intentionally delegates precedent matching, atom mapping, reaction
+centre/context extraction, and functional-group compatibility to the official
+engine.  The optional dependency is imported only when an operator explicitly
+constructs :class:`OfficialChemCensorScorer`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from importlib import metadata
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+from deepretro.evaluation.cache import ScoreCache
+from deepretro.evaluation.io import file_sha256
+from deepretro.evaluation.types import (
+    CanonicalPrediction,
+    ChemCensorProvenance,
+    ChemCensorScore,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ChemCensorUnavailableError(RuntimeError):
+    """Raised when the optional official scorer cannot be initialized."""
+
+
+class OfficialChemCensorScorer:
+    """Score canonical DeepRetro predictions with a local official engine.
+
+    Parameters are deliberately a subset of the official constructor.  Tests
+    inject a module loader; production callers supply an approved local SQLite
+    database and a compatible ``chemcensor`` installation.
+    """
+
+    def __init__(
+        self,
+        database_path: str | Path,
+        *,
+        database_version: str,
+        max_center_type: int = 4,
+        find_exact_match: bool = True,
+        cache_path: str | Path | None = None,
+        module_loader: Callable[[str], ModuleType] = importlib.import_module,
+        package_version_getter: Callable[[str], str] = metadata.version,
+    ) -> None:
+        """Initialize the official scorer and immutable provenance payload."""
+        if sys.version_info < (3, 12):
+            raise ChemCensorUnavailableError(
+                "the optional ChemCensor package requires Python 3.12 or later"
+            )
+        if isinstance(max_center_type, bool) or not isinstance(max_center_type, int):
+            raise ValueError("max_center_type must be an integer")
+        if max_center_type < 1:
+            raise ValueError("max_center_type must be positive")
+        if not isinstance(find_exact_match, bool):
+            raise ValueError("find_exact_match must be a boolean")
+
+        self._database_path = Path(database_path).expanduser().resolve()
+        if not self._database_path.is_file():
+            raise FileNotFoundError(
+                f"ChemCensor database does not exist: {self._database_path}"
+            )
+        try:
+            module = module_loader("chemcensor")
+        except ModuleNotFoundError as exc:
+            dependency_hint = (
+                "the optional ChemCensor package is not installed"
+                if exc.name in {None, "chemcensor"}
+                else f"the optional ChemCensor dependency {exc.name!r} is missing"
+            )
+            raise ChemCensorUnavailableError(
+                f"{dependency_hint}; install a compatible local official release "
+                "to use score"
+            ) from exc
+
+        factory = getattr(module, "ChemCensor", None)
+        if not callable(factory):
+            raise ChemCensorUnavailableError(
+                "the installed ChemCensor package does not expose ChemCensor"
+            )
+        try:
+            self._engine = factory(
+                db_path=self._database_path,
+                max_center_type=max_center_type,
+                find_exact_match=find_exact_match,
+            )
+        except Exception as exc:  # external database/configuration boundary
+            raise ChemCensorUnavailableError(
+                f"failed to initialize the official ChemCensor engine: {exc}"
+            ) from exc
+        if not callable(getattr(self._engine, "evaluate", None)):
+            raise ChemCensorUnavailableError(
+                "the installed ChemCensor release does not provide evaluate(); "
+                "a dual-score release is required"
+            )
+
+        try:
+            package_version = package_version_getter("chemcensor")
+        except metadata.PackageNotFoundError:
+            package_version = "unknown"
+        self.provenance = ChemCensorProvenance(
+            scorer_name="chemcensor",
+            package_version=package_version,
+            database_filename=self._database_path.name,
+            database_version=database_version,
+            database_sha256=file_sha256(self._database_path),
+            database_size_bytes=self._database_path.stat().st_size,
+            max_center_type=max_center_type,
+            find_exact_match=find_exact_match,
+        )
+        self._cache: ScoreCache | None = None
+        if cache_path is not None:
+            try:
+                self._cache = ScoreCache(cache_path)
+            except Exception as exc:  # cache is a performance optimization only
+                logger.warning(
+                    "ChemCensor score cache initialization failed; bypassing cache: %s",
+                    exc,
+                )
+
+    def score_prediction(self, prediction: CanonicalPrediction) -> ChemCensorScore:
+        """Return official dual scores, retaining invalid and failed outputs."""
+        if not prediction.is_valid:
+            return ChemCensorScore(
+                prediction_id=prediction.prediction.prediction_id,
+                canonical_reaction_smiles=None,
+                with_functional_groups=None,
+                without_functional_groups=None,
+                status="invalid",
+                provenance=None,
+                error=prediction.error or "invalid prediction",
+            )
+
+        reaction_smiles = prediction.canonical_reaction_smiles
+        assert reaction_smiles is not None
+        if self._cache is not None:
+            cached_score = self._get_cached_score(reaction_smiles, prediction)
+            if cached_score is not None:
+                return cached_score
+        try:
+            result = self._engine.evaluate(reaction_smiles)
+            with_functional_groups = _coerce_official_score(
+                getattr(result, "with_functional_groups"),
+                "with_functional_groups",
+            )
+            without_functional_groups = _coerce_official_score(
+                getattr(result, "without_functional_groups"),
+                "without_functional_groups",
+            )
+            status = _status_from_official_scores(
+                with_functional_groups,
+                without_functional_groups,
+            )
+            score = ChemCensorScore(
+                prediction_id=prediction.prediction.prediction_id,
+                canonical_reaction_smiles=reaction_smiles,
+                with_functional_groups=with_functional_groups,
+                without_functional_groups=without_functional_groups,
+                status=status,
+                provenance=self.provenance,
+            )
+        except Exception as exc:  # a per-reaction external-engine boundary
+            return ChemCensorScore(
+                prediction_id=prediction.prediction.prediction_id,
+                canonical_reaction_smiles=reaction_smiles,
+                with_functional_groups=-1.0,
+                without_functional_groups=-1.0,
+                status="processing_failed",
+                provenance=self.provenance,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        self._store_cached_score(score)
+        return score
+
+    def _get_cached_score(
+        self,
+        reaction_smiles: str,
+        prediction: CanonicalPrediction,
+    ) -> ChemCensorScore | None:
+        """Read an optional cache without letting it alter scorer semantics."""
+        assert self._cache is not None
+        try:
+            return self._cache.get(
+                reaction_smiles,
+                self.provenance,
+                prediction_id=prediction.prediction.prediction_id,
+            )
+        except Exception as exc:  # cache is a performance optimization only
+            logger.warning("ChemCensor score cache read failed; bypassing cache: %s", exc)
+            return None
+
+    def _store_cached_score(self, score: ChemCensorScore) -> None:
+        """Attempt a cache write without converting a good result into failure."""
+        if self._cache is None:
+            return
+        try:
+            self._cache.put(score)
+        except Exception as exc:  # cache is a performance optimization only
+            logger.warning("ChemCensor score cache write failed; bypassing cache: %s", exc)
+
+
+def _status_from_official_scores(
+    with_functional_groups: float,
+    without_functional_groups: float,
+) -> str:
+    """Map the official paired score sentinels to the public status vocabulary."""
+    if with_functional_groups == -1.0 and without_functional_groups == -1.0:
+        return "processing_failed"
+    if with_functional_groups == 0.0 and without_functional_groups == 0.0:
+        return "no_precedent"
+    if with_functional_groups > 0.0 and without_functional_groups > 0.0:
+        return "scored"
+    raise ValueError("official ChemCensor result has inconsistent score variants")
+
+
+def _coerce_official_score(value: Any, field_name: str) -> float:
+    """Reject undocumented score shapes instead of silently changing metrics."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"official {field_name} score is not numeric")
+    numeric_value = float(value)
+    if not -1.0 <= numeric_value <= 5.0:
+        raise ValueError(f"official {field_name} score is outside [-1, 5]")
+    return numeric_value

--- a/deepretro/evaluation/cli.py
+++ b/deepretro/evaluation/cli.py
@@ -1,0 +1,143 @@
+"""Command-line interface for optional scoring and offline aggregation."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from deepretro.evaluation.aggregate import aggregate_benchmark
+from deepretro.evaluation.chemcensor import (
+    ChemCensorUnavailableError,
+    OfficialChemCensorScorer,
+)
+from deepretro.evaluation.io import load_predictions, load_scores, load_targets, write_scores
+from deepretro.evaluation.report import write_benchmark_report, write_score_provenance
+from deepretro.evaluation.runner import score_predictions
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run ``score`` or ``aggregate`` and return a shell-compatible status."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "score":
+            _run_score(args)
+        elif args.command == "aggregate":
+            _run_aggregate(args)
+        else:  # pragma: no cover - argparse enforces the available choices
+            parser.error(f"unknown command: {args.command}")
+    except (ChemCensorUnavailableError, FileNotFoundError, ValueError) as exc:
+        print(f"deepretro evaluation: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the intentionally narrow offline-only command contract."""
+    parser = argparse.ArgumentParser(
+        prog="python -m deepretro.evaluation",
+        description=(
+            "Offline ChemCensor plausibility evaluation for DeepRetro. "
+            "'aggregate' runs on any supported interpreter; 'score' additionally "
+            "requires Python >=3.12 and a local ChemCensor install."
+        ),
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    score = commands.add_parser(
+        "score",
+        help=(
+            "run an approved local official ChemCensor installation "
+            "(requires Python >=3.12 and a local ChemCensor install)"
+        ),
+    )
+    _add_input_arguments(score)
+    score.add_argument("--database", required=True, help="local official SQLite database")
+    score.add_argument("--database-version", required=True)
+    score.add_argument("--scores-out", required=True)
+    score.add_argument("--provenance-out", required=True)
+    score.add_argument("--cache", help="optional local SQLite score cache")
+    score.add_argument("--max-center-type", type=int, default=4)
+    score.add_argument(
+        "--no-find-exact-match",
+        action="store_true",
+        help="disable official exact-reaction lookup optimization",
+    )
+
+    aggregate = commands.add_parser(
+        "aggregate",
+        help="aggregate an existing score artifact without ChemCensor installed",
+    )
+    _add_input_arguments(aggregate)
+    aggregate.add_argument("--scores", required=True)
+    aggregate.add_argument("--k", type=int, default=10)
+    aggregate.add_argument(
+        "--score-variant",
+        choices=("with_functional_groups", "without_functional_groups"),
+        default="with_functional_groups",
+    )
+    aggregate.add_argument("--report-out", required=True)
+    return parser
+
+
+def _add_input_arguments(parser: argparse.ArgumentParser) -> None:
+    """Share the explicit benchmark contract between both subcommands."""
+    parser.add_argument("--predictions", required=True)
+    parser.add_argument("--targets", required=True)
+
+
+def _run_score(args: argparse.Namespace) -> None:
+    """Score every prediction with a locally installed official engine."""
+    predictions = load_predictions(args.predictions)
+    targets = load_targets(args.targets)
+    _validate_prediction_targets(predictions, {target.target_id for target in targets})
+    scorer = OfficialChemCensorScorer(
+        args.database,
+        database_version=args.database_version,
+        max_center_type=args.max_center_type,
+        find_exact_match=not args.no_find_exact_match,
+        cache_path=args.cache,
+    )
+    scores = score_predictions(predictions, scorer)
+    write_scores(args.scores_out, scores)
+    write_score_provenance(
+        args.provenance_out,
+        scores,
+        predictions_path=args.predictions,
+        targets_path=args.targets,
+    )
+
+
+def _run_aggregate(args: argparse.Namespace) -> None:
+    """Compute benchmark metrics from a portable score JSONL artifact."""
+    predictions = load_predictions(args.predictions)
+    targets = load_targets(args.targets)
+    scores = load_scores(args.scores)
+    evaluation = aggregate_benchmark(
+        targets,
+        predictions,
+        scores,
+        k=args.k,
+        score_variant=args.score_variant,
+    )
+    write_benchmark_report(
+        args.report_out,
+        evaluation,
+        score_variant=args.score_variant,
+        predictions_path=args.predictions,
+        targets_path=args.targets,
+        scores_path=args.scores,
+    )
+
+
+def _validate_prediction_targets(predictions, target_ids: set[str]) -> None:
+    """Fail early when a score run would use an unknown target."""
+    if not target_ids:
+        raise ValueError("targets must contain at least one target")
+    for prediction in predictions:
+        if prediction.target_id not in target_ids:
+            raise ValueError(
+                f"prediction {prediction.prediction_id!r} references unknown target "
+                f"{prediction.target_id!r}"
+            )

--- a/deepretro/evaluation/io.py
+++ b/deepretro/evaluation/io.py
@@ -1,0 +1,260 @@
+"""Versioned JSONL input/output for offline evaluation runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from deepretro.evaluation.types import (
+    ChemCensorProvenance,
+    ChemCensorScore,
+    EvaluationTarget,
+    SingleStepPrediction,
+)
+
+SCORE_ARTIFACT_SCHEMA_VERSION = 1
+_PROVENANCE_FIELDS = {
+    "scorer_name",
+    "package_version",
+    "database_filename",
+    "database_version",
+    "database_sha256",
+    "database_size_bytes",
+    "max_center_type",
+    "find_exact_match",
+}
+
+
+def load_predictions(path: str | Path) -> list[SingleStepPrediction]:
+    """Load ranked precursor-set predictions from the documented JSONL schema."""
+    predictions: list[SingleStepPrediction] = []
+    prediction_ids: set[str] = set()
+    ranks_by_target: dict[str, set[int]] = {}
+    for line_number, record in _read_jsonl(path):
+        _require_exact_keys(
+            record,
+            required={
+                "prediction_id",
+                "target_id",
+                "rank",
+                "product_smiles",
+                "precursor_smiles",
+            },
+            optional={"metadata"},
+            source=f"{path}:{line_number}",
+        )
+        precursor_smiles = record["precursor_smiles"]
+        if not isinstance(precursor_smiles, list):
+            raise ValueError(f"{path}:{line_number}: precursor_smiles must be a list")
+        prediction = SingleStepPrediction(
+            prediction_id=record["prediction_id"],
+            target_id=record["target_id"],
+            rank=record["rank"],
+            product_smiles=record["product_smiles"],
+            precursor_smiles=tuple(precursor_smiles),
+            metadata=_metadata_or_empty(record.get("metadata"), path, line_number),
+        )
+        if prediction.prediction_id in prediction_ids:
+            raise ValueError(f"{path}:{line_number}: duplicate prediction_id")
+        target_ranks = ranks_by_target.setdefault(prediction.target_id, set())
+        if prediction.rank in target_ranks:
+            raise ValueError(
+                f"{path}:{line_number}: duplicate rank {prediction.rank} for "
+                f"target {prediction.target_id!r}"
+            )
+        prediction_ids.add(prediction.prediction_id)
+        target_ranks.add(prediction.rank)
+        predictions.append(prediction)
+    return predictions
+
+
+def load_targets(path: str | Path) -> list[EvaluationTarget]:
+    """Load the explicit benchmark target denominator from JSONL."""
+    targets: list[EvaluationTarget] = []
+    target_ids: set[str] = set()
+    for line_number, record in _read_jsonl(path):
+        _require_exact_keys(
+            record,
+            required={"target_id", "product_smiles"},
+            optional={"reference_precursor_smiles", "metadata"},
+            source=f"{path}:{line_number}",
+        )
+        reference_precursors = record.get("reference_precursor_smiles")
+        if reference_precursors is not None and not isinstance(reference_precursors, list):
+            raise ValueError(
+                f"{path}:{line_number}: reference_precursor_smiles must be a list"
+            )
+        target = EvaluationTarget(
+            target_id=record["target_id"],
+            product_smiles=record["product_smiles"],
+            reference_precursor_smiles=(
+                None if reference_precursors is None else tuple(reference_precursors)
+            ),
+            metadata=_metadata_or_empty(record.get("metadata"), path, line_number),
+        )
+        if target.target_id in target_ids:
+            raise ValueError(f"{path}:{line_number}: duplicate target_id")
+        target_ids.add(target.target_id)
+        targets.append(target)
+    return targets
+
+
+def write_scores(path: str | Path, scores: Sequence[ChemCensorScore]) -> None:
+    """Write a deterministic, self-describing score artifact JSONL file."""
+    score_ids: set[str] = set()
+    for score in scores:
+        if score.prediction_id in score_ids:
+            raise ValueError(f"duplicate prediction_id: {score.prediction_id!r}")
+        score_ids.add(score.prediction_id)
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8", newline="\n") as handle:
+        for score in scores:
+            handle.write(json.dumps(_score_record(score), sort_keys=True))
+            handle.write("\n")
+
+
+def load_scores(path: str | Path) -> list[ChemCensorScore]:
+    """Load a score artifact and validate its schema/status invariants."""
+    scores: list[ChemCensorScore] = []
+    score_ids: set[str] = set()
+    for line_number, record in _read_jsonl(path):
+        _require_exact_keys(
+            record,
+            required={
+                "schema_version",
+                "prediction_id",
+                "canonical_reaction_smiles",
+                "with_functional_groups",
+                "without_functional_groups",
+                "status",
+                "provenance",
+                "error",
+            },
+            optional=set(),
+            source=f"{path}:{line_number}",
+        )
+        schema_version = record["schema_version"]
+        if (
+            isinstance(schema_version, bool)
+            or not isinstance(schema_version, int)
+            or schema_version != SCORE_ARTIFACT_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                f"{path}:{line_number}: schema_version must be integer "
+                f"{SCORE_ARTIFACT_SCHEMA_VERSION}"
+            )
+        provenance_record = record["provenance"]
+        if provenance_record is not None and not isinstance(provenance_record, Mapping):
+            raise ValueError(f"{path}:{line_number}: provenance must be an object or null")
+        if provenance_record is not None:
+            _require_exact_keys(
+                provenance_record,
+                required=_PROVENANCE_FIELDS,
+                optional=set(),
+                source=f"{path}:{line_number}:provenance",
+            )
+        try:
+            provenance = (
+                None
+                if provenance_record is None
+                else ChemCensorProvenance(**dict(provenance_record))
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{path}:{line_number}: invalid provenance: {exc}") from exc
+        try:
+            score = ChemCensorScore(
+                prediction_id=record["prediction_id"],
+                canonical_reaction_smiles=record["canonical_reaction_smiles"],
+                with_functional_groups=record["with_functional_groups"],
+                without_functional_groups=record["without_functional_groups"],
+                status=record["status"],
+                provenance=provenance,
+                error=record["error"],
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{path}:{line_number}: invalid score record: {exc}") from exc
+        if score.prediction_id in score_ids:
+            raise ValueError(f"{path}:{line_number}: duplicate prediction_id")
+        score_ids.add(score.prediction_id)
+        scores.append(score)
+    return scores
+
+
+def file_sha256(path: str | Path) -> str:
+    """Return a streamed SHA-256 digest for artifact provenance sidecars."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_jsonl(path: str | Path) -> Iterable[tuple[int, dict[str, Any]]]:
+    """Yield nonblank object records with file/line-contextual validation."""
+    source = Path(path)
+    with source.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            if not raw_line.strip():
+                continue
+            try:
+                record = json.loads(raw_line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{source}:{line_number}: invalid JSON") from exc
+            if not isinstance(record, dict):
+                raise ValueError(f"{source}:{line_number}: each JSONL row must be an object")
+            yield line_number, record
+
+
+def _require_exact_keys(
+    record: Mapping[str, Any],
+    *,
+    required: set[str],
+    optional: set[str],
+    source: str,
+) -> None:
+    """Reject missing and unknown fields instead of silently changing contracts."""
+    missing = required - record.keys()
+    unknown = record.keys() - required - optional
+    if missing:
+        raise ValueError(f"{source}: missing required fields: {sorted(missing)}")
+    if unknown:
+        raise ValueError(f"{source}: unknown fields: {sorted(unknown)}")
+
+
+def _metadata_or_empty(value: Any, path: str | Path, line_number: int) -> Mapping[str, Any]:
+    """Normalize optional metadata while keeping the primary schema strict."""
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{path}:{line_number}: metadata must be an object")
+    return dict(value)
+
+
+def _score_record(score: ChemCensorScore) -> dict[str, Any]:
+    """Serialize a score without relying on non-JSON dataclass internals."""
+    return {
+        "schema_version": SCORE_ARTIFACT_SCHEMA_VERSION,
+        "prediction_id": score.prediction_id,
+        "canonical_reaction_smiles": score.canonical_reaction_smiles,
+        "with_functional_groups": score.with_functional_groups,
+        "without_functional_groups": score.without_functional_groups,
+        "status": score.status,
+        "provenance": (
+            None
+            if score.provenance is None
+            else {
+                "scorer_name": score.provenance.scorer_name,
+                "package_version": score.provenance.package_version,
+                "database_filename": score.provenance.database_filename,
+                "database_version": score.provenance.database_version,
+                "database_sha256": score.provenance.database_sha256,
+                "database_size_bytes": score.provenance.database_size_bytes,
+                "max_center_type": score.provenance.max_center_type,
+                "find_exact_match": score.provenance.find_exact_match,
+            }
+        ),
+        "error": score.error,
+    }

--- a/deepretro/evaluation/report.py
+++ b/deepretro/evaluation/report.py
@@ -1,0 +1,105 @@
+"""Human-auditable JSON report and provenance-sidecar generation."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+from deepretro.evaluation.aggregate import BenchmarkEvaluation, ScoreVariant
+from deepretro.evaluation.io import file_sha256
+from deepretro.evaluation.types import ChemCensorScore
+
+REPORT_SCHEMA_VERSION = 1
+SCORE_PROVENANCE_SCHEMA_VERSION = 1
+
+
+def write_benchmark_report(
+    path: str | Path,
+    evaluation: BenchmarkEvaluation,
+    *,
+    score_variant: ScoreVariant,
+    predictions_path: str | Path,
+    targets_path: str | Path,
+    scores_path: str | Path,
+) -> None:
+    """Write aggregate metrics, diagnostics, and artifact hashes as JSON."""
+    payload = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "score_variant": score_variant,
+        "metrics": {
+            "target_count": evaluation.target_count,
+            "prediction_coverage": evaluation.prediction_coverage,
+            "average_pt_max_cc": evaluation.average_pt_max_cc,
+            "average_pt_top_k_cc": evaluation.average_pt_top_k_cc,
+            "reference_target_count": evaluation.reference_target_count,
+            "average_exact_match_at_k": evaluation.average_exact_match_at_k,
+        },
+        "targets": [asdict(target) for target in evaluation.target_evaluations],
+        "artifacts": {
+            "predictions_sha256": file_sha256(predictions_path),
+            "targets_sha256": file_sha256(targets_path),
+            "scores_sha256": file_sha256(scores_path),
+        },
+        "limitations": [
+            "ChemCensor is precedent-based: a no-precedent score is not proof "
+            "that a reaction is chemically invalid.",
+            "PT metrics evaluate single-step proposals; they are not a complete "
+            "multi-step route feasibility score.",
+        ],
+    }
+    _write_json(path, payload)
+
+
+def write_score_provenance(
+    path: str | Path,
+    scores: Sequence[ChemCensorScore],
+    *,
+    predictions_path: str | Path,
+    targets_path: str | Path,
+) -> None:
+    """Write scorer/database identity and source-input hashes beside score JSONL."""
+    status_counts = Counter(score.status for score in scores)
+    provenance_rows = {
+        _provenance_key(score): asdict(score.provenance)
+        for score in scores
+        if score.provenance is not None
+    }
+    payload = {
+        "schema_version": SCORE_PROVENANCE_SCHEMA_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "artifacts": {
+            "predictions_sha256": file_sha256(predictions_path),
+            "targets_sha256": file_sha256(targets_path),
+        },
+        "score_status_counts": dict(sorted(status_counts.items())),
+        "scorer_provenance": list(provenance_rows.values()),
+    }
+    _write_json(path, payload)
+
+
+def _provenance_key(score: ChemCensorScore) -> tuple[object, ...]:
+    """Return a hashable identity for deterministic provenance de-duplication."""
+    assert score.provenance is not None
+    provenance = score.provenance
+    return (
+        provenance.scorer_name,
+        provenance.package_version,
+        provenance.database_version,
+        provenance.database_sha256,
+        provenance.max_center_type,
+        provenance.find_exact_match,
+    )
+
+
+def _write_json(path: str | Path, payload: object) -> None:
+    """Write formatted JSON atomically enough for local offline artifacts."""
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/deepretro/evaluation/runner.py
+++ b/deepretro/evaluation/runner.py
@@ -1,0 +1,79 @@
+"""Orchestration for optional direct, local official scoring runs."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Protocol, Sequence
+
+from deepretro.evaluation.canonical import canonicalize_prediction
+from deepretro.evaluation.types import (
+    CanonicalPrediction,
+    ChemCensorScore,
+    SingleStepPrediction,
+)
+
+
+class PredictionScorer(Protocol):
+    """Minimal interface shared by the official scorer and test doubles."""
+
+    def score_prediction(self, prediction: CanonicalPrediction) -> ChemCensorScore:
+        """Return a normalized score for one canonicalized prediction."""
+
+
+def score_predictions(
+    predictions: Sequence[SingleStepPrediction],
+    scorer: PredictionScorer,
+) -> list[ChemCensorScore]:
+    """Score predictions once per canonical reaction in stable input order.
+
+    The output deliberately remains one row per original prediction so that an
+    aggregate can validate the score artifact against every input prediction. A
+    duplicate's score is rebound to its own ID without repeating the expensive
+    external precedent lookup.
+
+    Prediction-id uniqueness is enforced at the I/O boundary
+    (:func:`deepretro.evaluation.io.load_predictions` on input and
+    :func:`deepretro.evaluation.io.write_scores` on output), so it is not
+    re-checked here.
+    """
+    scores: list[ChemCensorScore] = []
+    by_reaction: dict[str, ChemCensorScore] = {}
+    for prediction in predictions:
+        canonical_prediction = canonicalize_prediction(prediction)
+        reaction_smiles = canonical_prediction.canonical_reaction_smiles
+        if reaction_smiles is not None and reaction_smiles in by_reaction:
+            scores.append(
+                replace(
+                    by_reaction[reaction_smiles],
+                    prediction_id=prediction.prediction_id,
+                )
+            )
+            continue
+
+        score = scorer.score_prediction(canonical_prediction)
+        _validate_scorer_output(canonical_prediction, score)
+        scores.append(score)
+        if reaction_smiles is not None:
+            by_reaction[reaction_smiles] = score
+    return scores
+
+
+def _validate_scorer_output(
+    prediction: CanonicalPrediction,
+    score: ChemCensorScore,
+) -> None:
+    """Prevent a third-party scorer bug from producing a mismatched artifact."""
+    prediction_id = prediction.prediction.prediction_id
+    if score.prediction_id != prediction_id:
+        raise ValueError(
+            f"scorer returned prediction_id {score.prediction_id!r} for {prediction_id!r}"
+        )
+    if prediction.is_valid:
+        if score.canonical_reaction_smiles != prediction.canonical_reaction_smiles:
+            raise ValueError(
+                f"scorer returned a reaction different from prediction {prediction_id!r}"
+            )
+    elif score.status != "invalid":
+        raise ValueError(
+            f"scorer returned non-invalid status for invalid prediction {prediction_id!r}"
+        )

--- a/deepretro/evaluation/types.py
+++ b/deepretro/evaluation/types.py
@@ -1,0 +1,235 @@
+"""Public value types for single-step plausibility evaluation."""
+
+from __future__ import annotations
+
+import math
+import string
+from dataclasses import dataclass, field
+from typing import Any, Literal, Mapping
+
+
+def _require_text(value: str, field_name: str) -> None:
+    """Reject blank identifiers and SMILES fields at the public boundary."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class SingleStepPrediction:
+    """One ranked DeepRetro-style precursor-set prediction.
+
+    The prediction represents a retrosynthetic proposal: ``product_smiles`` is
+    the target-side molecule and ``precursor_smiles`` is the proposed set of
+    immediate precursors.  Evaluation canonicalizes it into the forward
+    reaction form required by precedent scorers.
+    """
+
+    prediction_id: str
+    target_id: str
+    rank: int
+    product_smiles: str
+    precursor_smiles: tuple[str, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate structural fields without requiring RDKit parsing yet."""
+        _require_text(self.prediction_id, "prediction_id")
+        _require_text(self.target_id, "target_id")
+        _require_text(self.product_smiles, "product_smiles")
+        if isinstance(self.rank, bool) or not isinstance(self.rank, int):
+            raise ValueError("rank must be a positive integer")
+        if self.rank < 1:
+            raise ValueError("rank must be a positive integer")
+        if not isinstance(self.precursor_smiles, tuple):
+            raise ValueError("precursor_smiles must be a tuple")
+        if not self.precursor_smiles:
+            raise ValueError("precursor_smiles must contain at least one SMILES string")
+        for index, smiles in enumerate(self.precursor_smiles):
+            _require_text(smiles, f"precursor_smiles[{index}]")
+        if not isinstance(self.metadata, Mapping):
+            raise ValueError("metadata must be a mapping")
+
+
+@dataclass(frozen=True)
+class EvaluationTarget:
+    """One target in the explicit benchmark denominator.
+
+    ``reference_precursor_smiles`` is optional because exact-match remains a
+    companion diagnostic rather than a requirement for plausibility scoring.
+    """
+
+    target_id: str
+    product_smiles: str
+    reference_precursor_smiles: tuple[str, ...] | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate benchmark identity and optional single reference shape."""
+        _require_text(self.target_id, "target_id")
+        _require_text(self.product_smiles, "product_smiles")
+        if self.reference_precursor_smiles is not None:
+            if not isinstance(self.reference_precursor_smiles, tuple):
+                raise ValueError("reference_precursor_smiles must be a tuple")
+            if not self.reference_precursor_smiles:
+                raise ValueError(
+                    "reference_precursor_smiles must be non-empty when provided"
+                )
+            for index, smiles in enumerate(self.reference_precursor_smiles):
+                _require_text(smiles, f"reference_precursor_smiles[{index}]")
+        if not isinstance(self.metadata, Mapping):
+            raise ValueError("metadata must be a mapping")
+
+
+@dataclass(frozen=True)
+class CanonicalPrediction:
+    """A prediction after deterministic RDKit canonicalization.
+
+    Invalid LLM output is represented rather than discarded.  Such a record
+    has all canonical SMILES fields set to ``None`` and an explanatory error.
+    """
+
+    prediction: SingleStepPrediction
+    canonical_product_smiles: str | None
+    canonical_precursor_smiles: tuple[str, ...] | None
+    canonical_reaction_smiles: str | None
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        """Assert the valid/invalid shapes stay disjoint.
+
+        This record is constructed only internally by
+        :mod:`deepretro.evaluation.canonical`, so this is a light programmer
+        guard rather than a public-input validator.
+        """
+        if self.canonical_reaction_smiles is None:
+            assert self.error, "invalid canonical predictions require an error"
+        else:
+            assert (
+                self.canonical_product_smiles is not None
+                and self.canonical_precursor_smiles is not None
+            ), "valid canonical predictions require canonical product and precursors"
+
+    @property
+    def is_valid(self) -> bool:
+        """Whether this record is safe to send to an external scorer."""
+        return self.canonical_reaction_smiles is not None
+
+
+ScoreStatus = Literal["scored", "no_precedent", "processing_failed", "invalid"]
+
+
+@dataclass(frozen=True)
+class ChemCensorProvenance:
+    """Versioned identity of the local official scorer/database pairing."""
+
+    scorer_name: str
+    package_version: str
+    database_filename: str
+    database_version: str
+    database_sha256: str
+    database_size_bytes: int
+    max_center_type: int
+    find_exact_match: bool
+
+    def __post_init__(self) -> None:
+        """Reject incomplete provenance that would make a score irreproducible."""
+        for field_name in (
+            "scorer_name",
+            "package_version",
+            "database_filename",
+            "database_version",
+            "database_sha256",
+        ):
+            _require_text(getattr(self, field_name), field_name)
+        if len(self.database_sha256) != 64:
+            raise ValueError("database_sha256 must be a SHA-256 hex digest")
+        if any(character not in string.hexdigits for character in self.database_sha256):
+            raise ValueError("database_sha256 must be a SHA-256 hex digest")
+        if (
+            isinstance(self.database_size_bytes, bool)
+            or not isinstance(self.database_size_bytes, int)
+            or self.database_size_bytes < 0
+        ):
+            raise ValueError("database_size_bytes must be non-negative")
+        if isinstance(self.max_center_type, bool) or not isinstance(
+            self.max_center_type, int
+        ):
+            raise ValueError("max_center_type must be an integer")
+        if self.max_center_type < 1:
+            raise ValueError("max_center_type must be positive")
+        if not isinstance(self.find_exact_match, bool):
+            raise ValueError("find_exact_match must be a boolean")
+
+
+@dataclass(frozen=True)
+class ChemCensorScore:
+    """One normalized official ChemCensor result or a retained failure state."""
+
+    prediction_id: str
+    canonical_reaction_smiles: str | None
+    with_functional_groups: float | None
+    without_functional_groups: float | None
+    status: ScoreStatus
+    provenance: ChemCensorProvenance | None
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce status/score invariants at the public boundary."""
+        _require_text(self.prediction_id, "prediction_id")
+        if not isinstance(self.status, str) or self.status not in {
+            "scored",
+            "no_precedent",
+            "processing_failed",
+            "invalid",
+        }:
+            raise ValueError(f"unsupported ChemCensor score status: {self.status!r}")
+        if self.error is not None:
+            _require_text(self.error, "error")
+
+        if self.status == "invalid":
+            if self.canonical_reaction_smiles is not None:
+                raise ValueError("invalid scores cannot have a canonical reaction")
+            if self.provenance is not None:
+                raise ValueError("invalid scores cannot have provenance")
+            if (
+                self.with_functional_groups is not None
+                or self.without_functional_groups is not None
+            ):
+                raise ValueError("invalid scores cannot have numeric score values")
+            return
+
+        _require_text(self.canonical_reaction_smiles or "", "canonical_reaction_smiles")
+        if self.provenance is None:
+            raise ValueError("non-invalid scores require provenance")
+        if not isinstance(self.provenance, ChemCensorProvenance):
+            raise ValueError("provenance must be a ChemCensorProvenance instance")
+        with_functional_groups = _validate_score_value(
+            self.with_functional_groups,
+            "with_functional_groups",
+        )
+        without_functional_groups = _validate_score_value(
+            self.without_functional_groups,
+            "without_functional_groups",
+        )
+        if self.status == "no_precedent" and (
+            with_functional_groups != 0.0 or without_functional_groups != 0.0
+        ):
+            raise ValueError("no_precedent scores must be exactly 0")
+        if self.status == "processing_failed" and (
+            with_functional_groups != -1.0 or without_functional_groups != -1.0
+        ):
+            raise ValueError("processing_failed scores must be exactly -1")
+        if self.status == "scored" and (
+            with_functional_groups <= 0.0 or without_functional_groups <= 0.0
+        ):
+            raise ValueError("scored ChemCensor values must be positive")
+
+
+def _validate_score_value(value: float | None, field_name: str) -> float:
+    """Validate the documented ChemCensor numeric range."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a numeric ChemCensor score")
+    numeric_value = float(value)
+    if not math.isfinite(numeric_value) or not -1.0 <= numeric_value <= 5.0:
+        raise ValueError(f"{field_name} must be a finite score in [-1, 5]")
+    return numeric_value

--- a/deepretro/pyproject.toml
+++ b/deepretro/pyproject.toml
@@ -45,6 +45,9 @@ az = [
 [project.urls]
 Repository = "https://github.com/deepforestsci/DeepRetro"
 
+[project.scripts]
+deepretro-evaluate = "deepretro.evaluation.cli:main"
+
 [tool.setuptools.packages.find]
 where = [".."]
 include = ["deepretro*"]

--- a/deepretro/tests/evaluation/test_evaluation.py
+++ b/deepretro/tests/evaluation/test_evaluation.py
@@ -1,0 +1,142 @@
+"""Core-functionality tests for the offline ChemCensor evaluation pipeline.
+
+These cover the main flow end to end -- canonicalization, score orchestration
+with a scorer double, plausibility/diversity aggregation, and score-artifact
+round-tripping -- rather than every helper and validation branch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from deepretro.evaluation.aggregate import aggregate_benchmark, evaluate_target
+from deepretro.evaluation.canonical import canonicalize_prediction
+from deepretro.evaluation.io import load_scores, write_scores
+from deepretro.evaluation.runner import score_predictions
+from deepretro.evaluation.types import (
+    CanonicalPrediction,
+    ChemCensorProvenance,
+    ChemCensorScore,
+    EvaluationTarget,
+    SingleStepPrediction,
+)
+
+
+def _provenance() -> ChemCensorProvenance:
+    return ChemCensorProvenance(
+        scorer_name="chemcensor",
+        package_version="1.2.0",
+        database_filename="ChemCensor.sqlite",
+        database_version="U2-1.0.0",
+        database_sha256="a" * 64,
+        database_size_bytes=123,
+        max_center_type=4,
+        find_exact_match=True,
+    )
+
+
+class _FakeScorer:
+    """Scorer double returning fixed dual scores and recording each call."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.provenance = _provenance()
+
+    def score_prediction(self, prediction: CanonicalPrediction) -> ChemCensorScore:
+        self.calls.append(prediction.canonical_reaction_smiles or "invalid")
+        if not prediction.is_valid:
+            return ChemCensorScore(
+                prediction_id=prediction.prediction.prediction_id,
+                canonical_reaction_smiles=None,
+                with_functional_groups=None,
+                without_functional_groups=None,
+                status="invalid",
+                provenance=None,
+                error="invalid",
+            )
+        return ChemCensorScore(
+            prediction_id=prediction.prediction.prediction_id,
+            canonical_reaction_smiles=prediction.canonical_reaction_smiles,
+            with_functional_groups=3.0,
+            without_functional_groups=4.0,
+            status="scored",
+            provenance=self.provenance,
+        )
+
+
+def test_canonicalization_builds_sorted_forward_reaction() -> None:
+    """Precursors are canonicalized and order-normalized into precursors>>product."""
+    prediction = SingleStepPrediction("p1", "target-1", 1, "OC(C)=O", ("O", "CCO"))
+
+    canonical = canonicalize_prediction(prediction)
+
+    assert canonical.is_valid
+    assert canonical.canonical_reaction_smiles == "CCO.O>>CC(=O)O"
+
+
+def test_canonicalization_flags_invalid_smiles() -> None:
+    """Invalid model output is retained as an audit record, not discarded."""
+    prediction = SingleStepPrediction("p1", "target-1", 1, "CC(=O)O", ("not-a-smiles",))
+
+    canonical = canonicalize_prediction(prediction)
+
+    assert not canonical.is_valid
+    assert canonical.canonical_reaction_smiles is None
+    assert canonical.error is not None
+
+
+def test_score_predictions_scores_each_reaction_once_and_rebinds_ids() -> None:
+    """Duplicate canonical reactions reuse one external lookup, one row per input."""
+    scorer = _FakeScorer()
+    predictions = [
+        SingleStepPrediction("p1", "target-1", 1, "CC(=O)O", ("CCO", "O")),
+        SingleStepPrediction("p2", "target-1", 2, "OC(C)=O", ("O", "C(O)C")),
+    ]
+
+    scores = score_predictions(predictions, scorer)
+
+    assert scorer.calls == ["CCO.O>>CC(=O)O"]
+    assert [score.prediction_id for score in scores] == ["p1", "p2"]
+    assert [score.with_functional_groups for score in scores] == [3.0, 3.0]
+
+
+def test_aggregate_rewards_distinct_predictions_over_full_target_denominator() -> None:
+    """PT-Max sees all uniques; PT-Top-K pads slots; empty targets stay counted."""
+    targets = [
+        EvaluationTarget("target-1", "CC(=O)O", reference_precursor_smiles=("CCO", "O")),
+        EvaluationTarget("target-2", "CCO"),
+    ]
+    predictions = [
+        SingleStepPrediction("p1", "target-1", 1, "CC(=O)O", ("CCO", "O")),
+        SingleStepPrediction("p2", "target-1", 2, "CC(=O)O", ("CCN", "O")),
+        SingleStepPrediction("p3", "target-1", 3, "CC(=O)O", ("CCO", "O")),
+    ]
+    scores = [
+        ChemCensorScore("p1", "CCO.O>>CC(=O)O", 3.0, 3.0, "scored", _provenance()),
+        ChemCensorScore("p2", "CCN.O>>CC(=O)O", 4.0, 4.0, "scored", _provenance()),
+        ChemCensorScore("p3", "CCO.O>>CC(=O)O", 3.0, 3.0, "scored", _provenance()),
+    ]
+
+    per_target = evaluate_target(targets[0], predictions, scores, k=3)
+    assert per_target.pt_max_cc == 4.0
+    assert per_target.unique_prediction_count == 2
+    assert per_target.duplicate_prediction_count == 1
+    assert per_target.exact_match_at_k is True
+
+    benchmark = aggregate_benchmark(targets, predictions, scores, k=3)
+    assert benchmark.target_count == 2
+    assert benchmark.prediction_coverage == 0.5
+    assert benchmark.average_pt_max_cc == 2.0  # (4.0 + 0.0) / 2 targets
+
+
+def test_score_artifact_round_trips_through_jsonl(tmp_path: Path) -> None:
+    """write_scores/load_scores preserve the dual score and its provenance."""
+    scores = [
+        ChemCensorScore("p1", "CCO.O>>CC(=O)O", 3.0, 4.0, "scored", _provenance()),
+    ]
+    artifact = tmp_path / "scores.jsonl"
+
+    write_scores(artifact, scores)
+    loaded = load_scores(artifact)
+
+    assert loaded == scores

--- a/deepretro/tests/evaluation/test_pipeline_end_to_end.py
+++ b/deepretro/tests/evaluation/test_pipeline_end_to_end.py
@@ -1,0 +1,159 @@
+"""End-to-end pipeline test for the ChemCensor evaluation subpackage.
+
+Runs a small, self-contained benchmark through the full offline path -- score via
+the public ``PredictionScorer`` protocol, write the JSONL artifact, then aggregate
+through the real CLI entry point -- and asserts the resulting report. It exercises
+every score state (scored, duplicate reaction, no_precedent, invalid) without the
+optional ChemCensor engine, so it runs on any supported interpreter.
+
+The ``score`` CLI subcommand is intentionally not exercised here: it requires the
+external ChemCensor package (Python >=3.12 + approved database), which is not a test
+dependency. Scoring is done in-process with a reference scorer instead.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from deepretro.evaluation.cli import main
+from deepretro.evaluation.io import write_scores
+from deepretro.evaluation.runner import score_predictions
+from deepretro.evaluation.types import (
+    CanonicalPrediction,
+    ChemCensorProvenance,
+    ChemCensorScore,
+    SingleStepPrediction,
+)
+
+# A tiny benchmark exercising all four score states. `confidence` in metadata drives
+# the reference scorer; 0.0 -> no_precedent, an unparseable precursor -> invalid, and
+# a repeated canonical reaction -> duplicate.
+_PREDICTIONS = [
+    # target "acid": two distinct scored disconnections + one duplicate of the first.
+    {"prediction_id": "a1", "target_id": "acid", "rank": 1,
+     "product_smiles": "CC(=O)O", "precursor_smiles": ["CCO", "O"],
+     "metadata": {"confidence": 0.9}},
+    {"prediction_id": "a2", "target_id": "acid", "rank": 2,
+     "product_smiles": "OC(C)=O", "precursor_smiles": ["CCO", "O"],  # dup reaction of a1
+     "metadata": {"confidence": 0.5}},
+    {"prediction_id": "a3", "target_id": "acid", "rank": 3,
+     "product_smiles": "CC(=O)O", "precursor_smiles": ["CC(=O)Cl", "O"],
+     "metadata": {"confidence": 0.7}},
+    # target "ethanol": one no_precedent (0 confidence) + one invalid precursor.
+    {"prediction_id": "b1", "target_id": "ethanol", "rank": 1,
+     "product_smiles": "CCO", "precursor_smiles": ["CC=O", "[H][H]"],
+     "metadata": {"confidence": 0.0}},
+    {"prediction_id": "b2", "target_id": "ethanol", "rank": 2,
+     "product_smiles": "CCO", "precursor_smiles": ["not-a-smiles"],
+     "metadata": {"confidence": 0.5}},
+]
+_TARGETS = [
+    {"target_id": "acid", "product_smiles": "CC(=O)O"},
+    {"target_id": "ethanol", "product_smiles": "CCO"},
+]
+
+
+class _ConfidenceScorer:
+    """Reference PredictionScorer mapping recorded confidence onto the score shape."""
+
+    def __init__(self) -> None:
+        self.provenance = ChemCensorProvenance(
+            scorer_name="reference-confidence",
+            package_version="0.1.0",
+            database_filename="reference.none",
+            database_version="ref-1",
+            database_sha256=hashlib.sha256(b"reference").hexdigest(),
+            database_size_bytes=9,
+            max_center_type=4,
+            find_exact_match=True,
+        )
+
+    def score_prediction(self, prediction: CanonicalPrediction) -> ChemCensorScore:
+        pid = prediction.prediction.prediction_id
+        if not prediction.is_valid:
+            return ChemCensorScore(
+                prediction_id=pid, canonical_reaction_smiles=None,
+                with_functional_groups=None, without_functional_groups=None,
+                status="invalid", provenance=None, error="invalid prediction",
+            )
+        confidence = float(prediction.prediction.metadata["confidence"])
+        if confidence <= 0.0:
+            value, status = 0.0, "no_precedent"
+        else:
+            value, status = round(1.0 + 4.0 * confidence, 3), "scored"
+        return ChemCensorScore(
+            prediction_id=pid,
+            canonical_reaction_smiles=prediction.canonical_reaction_smiles,
+            with_functional_groups=value, without_functional_groups=value,
+            status=status, provenance=self.provenance,
+        )
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+def test_full_pipeline_scores_and_aggregates_through_the_cli(tmp_path: Path) -> None:
+    predictions_path = tmp_path / "predictions.jsonl"
+    targets_path = tmp_path / "targets.jsonl"
+    scores_path = tmp_path / "scores.jsonl"
+    report_path = tmp_path / "report.json"
+    _write_jsonl(predictions_path, _PREDICTIONS)
+    _write_jsonl(targets_path, _TARGETS)
+
+    # Score in-process via the public runner + protocol scorer, write the artifact.
+    pred_objs = [
+        SingleStepPrediction(
+            prediction_id=p["prediction_id"], target_id=p["target_id"], rank=p["rank"],
+            product_smiles=p["product_smiles"],
+            precursor_smiles=tuple(p["precursor_smiles"]), metadata=p["metadata"],
+        )
+        for p in _PREDICTIONS
+    ]
+    scores = score_predictions(pred_objs, _ConfidenceScorer())
+    statuses = sorted(s.status for s in scores)
+    assert statuses == ["invalid", "no_precedent", "scored", "scored", "scored"]
+    write_scores(scores_path, scores)
+
+    # Aggregate through the real CLI entry point.
+    exit_code = main([
+        "aggregate",
+        "--predictions", str(predictions_path),
+        "--targets", str(targets_path),
+        "--scores", str(scores_path),
+        "--k", "3",
+        "--report-out", str(report_path),
+    ])
+    assert exit_code == 0
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    metrics = report["metrics"]
+    assert metrics["target_count"] == 2
+    assert metrics["prediction_coverage"] == 1.0
+    assert metrics["average_exact_match_at_k"] is None
+    # acid: pt_max = 4.6; ethanol: pt_max = 0.0  -> mean 2.3
+    assert metrics["average_pt_max_cc"] == pytest.approx(2.3)
+    # acid pt_top3 = (4.6 + 3.8) / 3; ethanol = 0  -> mean of the two
+    assert metrics["average_pt_top_k_cc"] == pytest.approx((8.4 / 3 + 0.0) / 2)
+
+    targets = {t["target_id"]: t for t in report["targets"]}
+    acid = targets["acid"]
+    assert acid["pt_max_cc"] == pytest.approx(4.6)
+    assert acid["top_k_values"] == [pytest.approx(4.6), pytest.approx(3.8), 0.0]
+    assert acid["unique_prediction_count"] == 2
+    assert acid["duplicate_prediction_count"] == 1
+    assert acid["scored_prediction_count"] == 2
+    assert acid["no_precedent_count"] == 0
+    assert acid["invalid_prediction_count"] == 0
+
+    ethanol = targets["ethanol"]
+    assert ethanol["pt_max_cc"] == 0.0
+    assert ethanol["no_precedent_count"] == 1
+    assert ethanol["invalid_prediction_count"] == 1
+    assert ethanol["scored_prediction_count"] == 0


### PR DESCRIPTION
Added deepretro/evaluation: an offline, research-facing harness that scores ranked single-step precursor predictions with the official ChemCensor engine and aggregates PT-Max / PT-Top-K plausibility metrics. 

## Description

Fix #(issue)

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings